### PR TITLE
Ajout des examens de textes en commission

### DIFF
--- a/aspirateur/tests/amendements/test_fetch_an.py
+++ b/aspirateur/tests/amendements/test_fetch_an.py
@@ -213,3 +213,36 @@ def test_fetch_amendement_not_found():
 
     with pytest.raises(NotFound):
         fetch_amendement(14, 4072, 177, SAMPLE_DATA_DIR)
+
+
+@pytest.mark.parametrize(
+    "division,type_,num,mult,pos",
+    [
+        (
+            {
+                "titre": "pour un État au service d’une société de confiance.",
+                "divisionDesignation": "TITRE",
+                "type": "TITRE",
+                "avantApres": "A",
+                "divisionRattache": "TITRE",
+                "articleAdditionnel": {
+                    "@xsi:nil": "true",
+                    "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                },
+                "divisionAdditionnelle": {
+                    "@xsi:nil": "true",
+                    "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                },
+                "urlDivisionTexteVise": "/15/textes/0575.asp#D_pour_un_Etat_au_service_dune_societe_d",  # noqa
+            },
+            "titre",
+            "",
+            "",
+            "",
+        )
+    ],
+)
+def test_parse_division(division, type_, num, mult, pos):
+    from zam_aspirateur.amendements.fetch_an import parse_division
+
+    assert parse_division(division) == (type_, num, mult, pos)

--- a/aspirateur/tests/amendements/test_parse.py
+++ b/aspirateur/tests/amendements/test_parse.py
@@ -194,7 +194,10 @@ class TestParseAmendementFromJSON:
     "text,type_,num,mult,pos",
     [
         ("", "", "", "", ""),
+        ("Intitulé du projet de loi", "titre", "", "", ""),
+        ("TITRE III : Un dispositif d'évaluation renouvelé", "section", "III", "", ""),
         ("Article 1", "article", "1", "", ""),
+        ("Article PREMIER", "article", "1", "", ""),
         (
             "Article 1er - Annexe (Stratégie nationale d'orientation de l'action publique)",  # noqa
             "article",
@@ -205,7 +208,15 @@ class TestParseAmendementFromJSON:
         ("Article 8\xa0bis", "article", "8", "bis", ""),
         ("art. add. après Article 7", "article", "7", "", "après"),
         ("art. add. avant Article 39", "article", "39", "", "avant"),
+        (
+            "Article(s) additionnel(s) après Article 15 ter",
+            "article",
+            "15",
+            "ter",
+            "après",
+        ),
         ("Article 31 (précédemment examiné)", "article", "31", "", ""),
+        ("Annexe", "annexe", "", "", ""),
         ("ANNEXE B", "annexe", "B", "", ""),
         ("Chapitre III", "chapitre", "III", "", ""),
     ],

--- a/aspirateur/tests/sample_data/dossier-DLR5L15N36030.json
+++ b/aspirateur/tests/sample_data/dossier-DLR5L15N36030.json
@@ -1,0 +1,1548 @@
+{
+    "dossierParlementaire": {
+        "@xsi:type": "DossierLegislatif_Type",
+        "uid": "DLR5L15N36030",
+        "legislature": "15",
+        "titreDossier": {
+            "titre": "Sécurité sociale : loi de financement 2018",
+            "titreChemin": "plfss_2018",
+            "senatChemin": "http://www.senat.fr/dossier-legislatif/plfss2018.html"
+        },
+        "procedureParlementaire": {
+            "code": "4",
+            "libelle": "Projet de loi de financement de la sécurité sociale"
+        },
+        "initiateur": {
+            "acteurs": {
+                "acteur": [
+                    {
+                        "acteurRef": "PA345619",
+                        "mandatRef": "PM725692"
+                    },
+                    {
+                        "acteurRef": "PA607846",
+                        "mandatRef": "PM730066"
+                    },
+                    {
+                        "acteurRef": "PA717153",
+                        "mandatRef": "PM730062"
+                    }
+                ]
+            }
+        },
+        "actesLegislatifs": {
+            "acteLegislatif": [
+                {
+                    "@xsi:type": "Etape_Type",
+                    "uid": "L15-AN1-36030",
+                    "codeActe": "AN1",
+                    "libelleActe": {
+                        "nomCanonique": "1ère lecture (1ère assemblée saisie)",
+                        "libelleCourt": "1ère lecture"
+                    },
+                    "organeRef": "PO717460",
+                    "dateActe": null,
+                    "actesLegislatifs": {
+                        "acteLegislatif": [
+                            {
+                                "@xsi:type": "DepotInitiative_Type",
+                                "uid": "L15-VD182969DI",
+                                "codeActe": "AN1-DEPOT",
+                                "libelleActe": {
+                                    "nomCanonique": "1er dépôt d'une initiative.",
+                                    "libelleCourt": "1er dépôt d'une initiative."
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": "2017-10-11T00:00:00.000+02:00",
+                                "actesLegislatifs": null,
+                                "texteAssocie": "PRJLANR5L15B0269"
+                            },
+                            {
+                                "@xsi:type": "EtudeImpact_Type",
+                                "uid": "L15-VD182969ETI",
+                                "codeActe": "AN1-ETI",
+                                "libelleActe": {
+                                    "nomCanonique": "Etude d'impact",
+                                    "libelleCourt": "Etude d'impact"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": "2017-10-11T00:00:00.000+02:00",
+                                "actesLegislatifs": null,
+                                "contributionInternaute": {
+                                    "dateOuverture": "2017-10-12+02:00",
+                                    "dateFermeture": "2017-10-24+02:00"
+                                },
+                                "texteAssocie": "ETDIANR5L15B0269"
+                            },
+                            {
+                                "@xsi:type": "ProcedureAccelere_Type",
+                                "uid": "L15-VD182971",
+                                "codeActe": "AN1-PROCACC",
+                                "libelleActe": {
+                                    "nomCanonique": "Le gouvernement déclare l'urgence / engage la procédure accélérée",
+                                    "libelleCourt": "Le gouvernement déclare l'urgence / engage la procédure accélérée"
+                                },
+                                "organeRef": "PO725688",
+                                "dateActe": "2017-10-11T00:00:00.000+02:00",
+                                "actesLegislatifs": null
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-AN1-COM-36030",
+                                "codeActe": "AN1-COM",
+                                "libelleActe": {
+                                    "nomCanonique": "Travaux des commissions",
+                                    "libelleCourt": "Travaux des commissions"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": [
+                                        {
+                                            "@xsi:type": "Etape_Type",
+                                            "uid": "L15-VD182970CF",
+                                            "codeActe": "AN1-COM-FOND",
+                                            "libelleActe": {
+                                                "nomCanonique": "Travaux de la commission saisie au fond",
+                                                "libelleCourt": "Travaux de la commission saisie au fond"
+                                            },
+                                            "organeRef": "PO420120",
+                                            "dateActe": null,
+                                            "actesLegislatifs": {
+                                                "acteLegislatif": [
+                                                    {
+                                                        "@xsi:type": "SaisieComFond_Type",
+                                                        "uid": "L15-VD182970CFS",
+                                                        "codeActe": "AN1-COM-FOND-SAISIE",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Renvoi en commission au fond",
+                                                            "libelleCourt": "Renvoi en commission au fond"
+                                                        },
+                                                        "organeRef": "PO420120",
+                                                        "dateActe": "2017-10-11T00:00:00.000+02:00",
+                                                        "actesLegislatifs": null
+                                                    },
+                                                    {
+                                                        "@xsi:type": "NominRapporteurs_Type",
+                                                        "uid": "L15-VD182990",
+                                                        "codeActe": "AN1-COM-FOND-NOMIN",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Nomination de rapporteur",
+                                                            "libelleCourt": "Nomination de rapporteur"
+                                                        },
+                                                        "organeRef": "PO420120",
+                                                        "dateActe": "2017-06-29T00:00:00.000+02:00",
+                                                        "actesLegislatifs": null,
+                                                        "rapporteurs": {
+                                                            "rapporteur": {
+                                                                "acteurRef": "PA642788",
+                                                                "typeRapporteur": "rapporteur"
+                                                            }
+                                                        },
+                                                        "reunion": null
+                                                    },
+                                                    {
+                                                        "@xsi:type": "DiscussionCommission_Type",
+                                                        "uid": "L15-VD183002R25170",
+                                                        "codeActe": "AN1-COM-FOND-REUNION",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Réunion de commission",
+                                                            "libelleCourt": "Réunion de commission"
+                                                        },
+                                                        "organeRef": "PO420120",
+                                                        "dateActe": "2017-10-11T16:30:00.000+02:00",
+                                                        "actesLegislatifs": null,
+                                                        "reunionRef": "RUANR5L15S2018IDC427340",
+                                                        "odjRef": "RUANR5L15S2018IDC427340PT25170"
+                                                    },
+                                                    {
+                                                        "@xsi:type": "DiscussionCommission_Type",
+                                                        "uid": "L15-VD183002R25167",
+                                                        "codeActe": "AN1-COM-FOND-REUNION",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Réunion de commission",
+                                                            "libelleCourt": "Réunion de commission"
+                                                        },
+                                                        "organeRef": "PO420120",
+                                                        "dateActe": "2017-10-17T17:00:00.000+02:00",
+                                                        "actesLegislatifs": null,
+                                                        "reunionRef": "RUANR5L15S2018IDC427270",
+                                                        "odjRef": "RUANR5L15S2018IDC427270PT25167"
+                                                    },
+                                                    {
+                                                        "@xsi:type": "DiscussionCommission_Type",
+                                                        "uid": "L15-VD183002R25166",
+                                                        "codeActe": "AN1-COM-FOND-REUNION",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Réunion de commission",
+                                                            "libelleCourt": "Réunion de commission"
+                                                        },
+                                                        "organeRef": "PO420120",
+                                                        "dateActe": "2017-10-17T21:30:00.000+02:00",
+                                                        "actesLegislatifs": null,
+                                                        "reunionRef": "RUANR5L15S2018IDC427271",
+                                                        "odjRef": "RUANR5L15S2018IDC427271PT25166"
+                                                    },
+                                                    {
+                                                        "@xsi:type": "DiscussionCommission_Type",
+                                                        "uid": "L15-VD183002R25168",
+                                                        "codeActe": "AN1-COM-FOND-REUNION",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Réunion de commission",
+                                                            "libelleCourt": "Réunion de commission"
+                                                        },
+                                                        "organeRef": "PO420120",
+                                                        "dateActe": "2017-10-18T09:30:00.000+02:00",
+                                                        "actesLegislatifs": null,
+                                                        "reunionRef": "RUANR5L15S2018IDC427356",
+                                                        "odjRef": "RUANR5L15S2018IDC427356PT25168"
+                                                    },
+                                                    {
+                                                        "@xsi:type": "DiscussionCommission_Type",
+                                                        "uid": "L15-VD183002R25169",
+                                                        "codeActe": "AN1-COM-FOND-REUNION",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Réunion de commission",
+                                                            "libelleCourt": "Réunion de commission"
+                                                        },
+                                                        "organeRef": "PO420120",
+                                                        "dateActe": "2017-10-18T16:15:00.000+02:00",
+                                                        "actesLegislatifs": null,
+                                                        "reunionRef": "RUANR5L15S2018IDC427272",
+                                                        "odjRef": "RUANR5L15S2018IDC427272PT25169"
+                                                    },
+                                                    {
+                                                        "@xsi:type": "DiscussionCommission_Type",
+                                                        "uid": "L15-VD183002R25177",
+                                                        "codeActe": "AN1-COM-FOND-REUNION",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Réunion de commission",
+                                                            "libelleCourt": "Réunion de commission"
+                                                        },
+                                                        "organeRef": "PO420120",
+                                                        "dateActe": "2017-10-24T14:30:00.000+02:00",
+                                                        "actesLegislatifs": null,
+                                                        "reunionRef": "RUANR5L15S2018IDC427494",
+                                                        "odjRef": "RUANR5L15S2018IDC427494PT25177"
+                                                    },
+                                                    {
+                                                        "@xsi:type": "DiscussionCommission_Type",
+                                                        "uid": "L15-VD183002R25184",
+                                                        "codeActe": "AN1-COM-FOND-REUNION",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Réunion de commission",
+                                                            "libelleCourt": "Réunion de commission"
+                                                        },
+                                                        "organeRef": "PO420120",
+                                                        "dateActe": "2017-10-26T16:25:00.000+02:00",
+                                                        "actesLegislatifs": null,
+                                                        "reunionRef": null,
+                                                        "odjRef": null
+                                                    },
+                                                    {
+                                                        "@xsi:type": "DepotRapport_Type",
+                                                        "uid": "L15-VD183107",
+                                                        "codeActe": "AN1-COM-FOND-RAPPORT",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Dépôt de rapport",
+                                                            "libelleCourt": "Dépôt de rapport"
+                                                        },
+                                                        "organeRef": "PO420120",
+                                                        "dateActe": "2017-10-19T00:00:00.000+02:00",
+                                                        "actesLegislatifs": null,
+                                                        "texteAssocie": "RAPPANR5L15B0316",
+                                                        "texteAdopte": null
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "@xsi:type": "Etape_Type",
+                                            "uid": "L15-VD182988CA",
+                                            "codeActe": "AN1-COM-AVIS",
+                                            "libelleActe": {
+                                                "nomCanonique": "Travaux d'une commission saisie pour avis",
+                                                "libelleCourt": "Travaux d'une commission saisie pour avis"
+                                            },
+                                            "organeRef": "PO59048",
+                                            "dateActe": null,
+                                            "actesLegislatifs": {
+                                                "acteLegislatif": [
+                                                    {
+                                                        "@xsi:type": "SaisieComAvis_Type",
+                                                        "uid": "L15-VD182988CAS",
+                                                        "codeActe": "AN1-COM-AVIS-SAISIE",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Saisine pour avis d'une commission",
+                                                            "libelleCourt": "Saisine pour avis d'une commission"
+                                                        },
+                                                        "organeRef": "PO59048",
+                                                        "dateActe": "2017-10-12T00:00:00.000+02:00",
+                                                        "actesLegislatifs": null
+                                                    },
+                                                    {
+                                                        "@xsi:type": "NominRapporteurs_Type",
+                                                        "uid": "L15-VD182989",
+                                                        "codeActe": "AN1-COM-AVIS-NOMIN",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Nomination de rapporteur",
+                                                            "libelleCourt": "Nomination de rapporteur"
+                                                        },
+                                                        "organeRef": "PO59048",
+                                                        "dateActe": "2017-07-18T00:00:00.000+02:00",
+                                                        "actesLegislatifs": null,
+                                                        "rapporteurs": {
+                                                            "rapporteur": {
+                                                                "acteurRef": "PA605963",
+                                                                "typeRapporteur": "rapporteur pour avis"
+                                                            }
+                                                        },
+                                                        "reunion": null
+                                                    },
+                                                    {
+                                                        "@xsi:type": "DiscussionCommission_Type",
+                                                        "uid": "L15-VD183002R25109",
+                                                        "codeActe": "AN1-COM-AVIS-REUNION",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Réunion de commission",
+                                                            "libelleCourt": "Réunion de commission"
+                                                        },
+                                                        "organeRef": "PO59048",
+                                                        "dateActe": "2017-10-18T09:35:00.000+02:00",
+                                                        "actesLegislatifs": null,
+                                                        "reunionRef": "RUANR5L15S2018IDC427386",
+                                                        "odjRef": "RUANR5L15S2018IDC427386PT25109"
+                                                    },
+                                                    {
+                                                        "@xsi:type": "DepotRapport_Type",
+                                                        "uid": "L15-VD183097",
+                                                        "codeActe": "AN1-COM-AVIS-RAPPORT",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Dépôt de rapport",
+                                                            "libelleCourt": "Dépôt de rapport"
+                                                        },
+                                                        "organeRef": "PO59048",
+                                                        "dateActe": "2017-10-18T00:00:00.000+02:00",
+                                                        "actesLegislatifs": null,
+                                                        "texteAssocie": "AVISANR5L15B0313",
+                                                        "texteAdopte": null
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-AN1-DEBATS-36030",
+                                "codeActe": "AN1-DEBATS",
+                                "libelleActe": {
+                                    "nomCanonique": "Discussion en séance publique",
+                                    "libelleCourt": "Discussion en séance publique"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": [
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD182975S35144",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-10-24T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20706",
+                                            "odjRef": "RUANR5L15S2018IDS20706PT35144"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD182975S35145",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-10-24T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20707",
+                                            "odjRef": "RUANR5L15S2018IDS20707PT35145"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD182975S35147",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-10-25T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20708",
+                                            "odjRef": "RUANR5L15S2018IDS20708PT35147"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD182975S35148",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-10-25T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20709",
+                                            "odjRef": "RUANR5L15S2018IDS20709PT35148"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD182975S35149",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-10-26T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20710",
+                                            "odjRef": "RUANR5L15S2018IDS20710PT35149"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD182975S35150",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-10-26T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20711",
+                                            "odjRef": "RUANR5L15S2018IDS20711PT35150"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD182975S35151",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-10-26T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20712",
+                                            "odjRef": "RUANR5L15S2018IDS20712PT35151"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD182975S35152",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-10-27T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20713",
+                                            "odjRef": "RUANR5L15S2018IDS20713PT35152"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD182975S35153",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-10-27T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20714",
+                                            "odjRef": "RUANR5L15S2018IDS20714PT35153"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD182975S35154",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-10-27T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20715",
+                                            "odjRef": "RUANR5L15S2018IDS20715PT35154"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD182975S35173",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-10-31T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20729",
+                                            "odjRef": "RUANR5L15S2018IDS20729PT35173"
+                                        },
+                                        {
+                                            "@xsi:type": "Decision_Type",
+                                            "uid": "L15-VD183219DEC",
+                                            "codeActe": "AN1-DEBATS-DEC",
+                                            "libelleActe": {
+                                                "nomCanonique": "Décision",
+                                                "libelleCourt": "Décision"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-10-31T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "statutConclusion": {
+                                                "fam_code": "TSORTF01",
+                                                "libelle": "adopté"
+                                            },
+                                            "reunionRef": "RUANR5L15S2018IDS20729",
+                                            "voteRefs": {
+                                                "voteRef": "VTANR5L15V208"
+                                            },
+                                            "textesAssocies": {
+                                                "texteAssocie": {
+                                                    "typeTexte": "BTA",
+                                                    "refTexteAssocie": "PRJLANR5L15BTA0029"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@xsi:type": "Etape_Type",
+                    "uid": "L15-SN1-36030",
+                    "codeActe": "SN1",
+                    "libelleActe": {
+                        "nomCanonique": "1ère lecture (2ème assemblée saisie)",
+                        "libelleCourt": "1ère lecture"
+                    },
+                    "organeRef": "PO78718",
+                    "dateActe": null,
+                    "actesLegislatifs": {
+                        "acteLegislatif": [
+                            {
+                                "@xsi:type": "DepotInitiativeNavette_Type",
+                                "uid": "L15-VD183287DIN",
+                                "codeActe": "SN1-DEPOT",
+                                "libelleActe": {
+                                    "nomCanonique": "Dépôt d'une initiative en navette",
+                                    "libelleCourt": "Dépôt d'une initiative en navette"
+                                },
+                                "organeRef": "PO78718",
+                                "dateActe": "2017-11-06T00:00:00.000+01:00",
+                                "actesLegislatifs": null,
+                                "texteAssocie": "PRJLSNR5S299B0063",
+                                "provenance": "PO717460"
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-SN1-COM-36030",
+                                "codeActe": "SN1-COM",
+                                "libelleActe": {
+                                    "nomCanonique": "Travaux des commissions",
+                                    "libelleCourt": "Travaux des commissions"
+                                },
+                                "organeRef": "PO78718",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": [
+                                        {
+                                            "@xsi:type": "Etape_Type",
+                                            "uid": "L15-VD183288CF",
+                                            "codeActe": "SN1-COM-FOND",
+                                            "libelleActe": {
+                                                "nomCanonique": "Travaux de la commission saisie au fond",
+                                                "libelleCourt": "Travaux de la commission saisie au fond"
+                                            },
+                                            "organeRef": "PO211493",
+                                            "dateActe": null,
+                                            "actesLegislatifs": {
+                                                "acteLegislatif": [
+                                                    {
+                                                        "@xsi:type": "SaisieComFond_Type",
+                                                        "uid": "L15-VD183288CFS",
+                                                        "codeActe": "SN1-COM-FOND-SAISIE",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Renvoi en commission au fond",
+                                                            "libelleCourt": "Renvoi en commission au fond"
+                                                        },
+                                                        "organeRef": "PO211493",
+                                                        "dateActe": "2017-11-06T00:00:00.000+01:00",
+                                                        "actesLegislatifs": null
+                                                    },
+                                                    {
+                                                        "@xsi:type": "NominRapporteurs_Type",
+                                                        "uid": "L15-VD183321",
+                                                        "codeActe": "SN1-COM-FOND-NOMIN",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Nomination de rapporteur",
+                                                            "libelleCourt": "Nomination de rapporteur"
+                                                        },
+                                                        "organeRef": "PO211493",
+                                                        "dateActe": "2017-10-11T00:00:00.000+02:00",
+                                                        "actesLegislatifs": null,
+                                                        "rapporteurs": {
+                                                            "rapporteur": [
+                                                                {
+                                                                    "acteurRef": "PA227098",
+                                                                    "typeRapporteur": "rapporteur"
+                                                                },
+                                                                {
+                                                                    "acteurRef": "PA425322",
+                                                                    "typeRapporteur": "rapporteur"
+                                                                },
+                                                                {
+                                                                    "acteurRef": "PA703498",
+                                                                    "typeRapporteur": "rapporteur"
+                                                                },
+                                                                {
+                                                                    "acteurRef": "PA429851",
+                                                                    "typeRapporteur": "rapporteur"
+                                                                },
+                                                                {
+                                                                    "acteurRef": "PA1090",
+                                                                    "typeRapporteur": "rapporteur"
+                                                                },
+                                                                {
+                                                                    "acteurRef": "PA342665",
+                                                                    "typeRapporteur": "rapporteur"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "reunion": null
+                                                    },
+                                                    {
+                                                        "@xsi:type": "DepotRapport_Type",
+                                                        "uid": "L15-VD183329",
+                                                        "codeActe": "SN1-COM-FOND-RAPPORT",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Dépôt de rapport",
+                                                            "libelleCourt": "Dépôt de rapport"
+                                                        },
+                                                        "organeRef": "PO211493",
+                                                        "dateActe": "2017-11-08T00:00:00.000+01:00",
+                                                        "actesLegislatifs": null,
+                                                        "texteAssocie": "RAPPSNR5S299B0077",
+                                                        "texteAdopte": null
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "@xsi:type": "Etape_Type",
+                                            "uid": "L15-VD183306CA",
+                                            "codeActe": "SN1-COM-AVIS",
+                                            "libelleActe": {
+                                                "nomCanonique": "Travaux d'une commission saisie pour avis",
+                                                "libelleCourt": "Travaux d'une commission saisie pour avis"
+                                            },
+                                            "organeRef": "PO211494",
+                                            "dateActe": null,
+                                            "actesLegislatifs": {
+                                                "acteLegislatif": [
+                                                    {
+                                                        "@xsi:type": "SaisieComAvis_Type",
+                                                        "uid": "L15-VD183306CAS",
+                                                        "codeActe": "SN1-COM-AVIS-SAISIE",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Saisine pour avis d'une commission",
+                                                            "libelleCourt": "Saisine pour avis d'une commission"
+                                                        },
+                                                        "organeRef": "PO211494",
+                                                        "dateActe": "2017-10-18T00:00:00.000+02:00",
+                                                        "actesLegislatifs": null
+                                                    },
+                                                    {
+                                                        "@xsi:type": "NominRapporteurs_Type",
+                                                        "uid": "L15-VD183307",
+                                                        "codeActe": "SN1-COM-AVIS-NOMIN",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Nomination de rapporteur",
+                                                            "libelleCourt": "Nomination de rapporteur"
+                                                        },
+                                                        "organeRef": "PO211494",
+                                                        "dateActe": "2017-10-18T00:00:00.000+02:00",
+                                                        "actesLegislatifs": null,
+                                                        "rapporteurs": {
+                                                            "rapporteur": {
+                                                                "acteurRef": "PA1744",
+                                                                "typeRapporteur": "rapporteur pour avis"
+                                                            }
+                                                        },
+                                                        "reunion": null
+                                                    },
+                                                    {
+                                                        "@xsi:type": "DepotRapport_Type",
+                                                        "uid": "L15-VD183308",
+                                                        "codeActe": "SN1-COM-AVIS-RAPPORT",
+                                                        "libelleActe": {
+                                                            "nomCanonique": "Dépôt de rapport",
+                                                            "libelleCourt": "Dépôt de rapport"
+                                                        },
+                                                        "organeRef": "PO211494",
+                                                        "dateActe": "2017-11-07T00:00:00.000+01:00",
+                                                        "actesLegislatifs": null,
+                                                        "texteAssocie": "AVISSNR5S299B0068",
+                                                        "texteAdopte": null
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-SN1-DEBATS-36030",
+                                "codeActe": "SN1-DEBATS",
+                                "libelleActe": {
+                                    "nomCanonique": "Discussion en séance publique",
+                                    "libelleCourt": "Discussion en séance publique"
+                                },
+                                "organeRef": "PO78718",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": [
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183289S35189",
+                                            "codeActe": "SN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO78718",
+                                            "dateActe": "2017-11-13T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUSNR5L15S2018IDS20738",
+                                            "odjRef": "RUSNR5L15S2018IDS20738PT35189"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183289S35191",
+                                            "codeActe": "SN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO78718",
+                                            "dateActe": "2017-11-14T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUSNR5L15S2018IDS20739",
+                                            "odjRef": "RUSNR5L15S2018IDS20739PT35191"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183289S35192",
+                                            "codeActe": "SN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO78718",
+                                            "dateActe": "2017-11-15T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUSNR5L15S2018IDS20740",
+                                            "odjRef": "RUSNR5L15S2018IDS20740PT35192"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183289S35193",
+                                            "codeActe": "SN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO78718",
+                                            "dateActe": "2017-11-16T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUSNR5L15S2018IDS20741",
+                                            "odjRef": "RUSNR5L15S2018IDS20741PT35193"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183289S35195",
+                                            "codeActe": "SN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO78718",
+                                            "dateActe": "2017-11-17T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUSNR5L15S2018IDS20742",
+                                            "odjRef": "RUSNR5L15S2018IDS20742PT35195"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183289S35274",
+                                            "codeActe": "SN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO78718",
+                                            "dateActe": "2017-11-21T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUSNR5L15S2018IDS20794",
+                                            "odjRef": "RUSNR5L15S2018IDS20794PT35274"
+                                        },
+                                        {
+                                            "@xsi:type": "Decision_Type",
+                                            "uid": "L15-VD183435DEC",
+                                            "codeActe": "SN1-DEBATS-DEC",
+                                            "libelleActe": {
+                                                "nomCanonique": "Décision",
+                                                "libelleCourt": "Décision"
+                                            },
+                                            "organeRef": "PO78718",
+                                            "dateActe": "2017-11-21T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "statutConclusion": {
+                                                "fam_code": "TSORTF05",
+                                                "libelle": "modifié"
+                                            },
+                                            "reunionRef": "RUSNR5L15S2018IDS20794",
+                                            "voteRefs": null,
+                                            "textesAssocies": {
+                                                "texteAssocie": {
+                                                    "typeTexte": "BTA",
+                                                    "refTexteAssocie": "PRJLSNR5S299BTA0020"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@xsi:type": "Etape_Type",
+                    "uid": "L15-CMP-36030",
+                    "codeActe": "CMP",
+                    "libelleActe": {
+                        "nomCanonique": "Commission Mixte Paritaire",
+                        "libelleCourt": "Commission Mixte Paritaire"
+                    },
+                    "organeRef": "PO743571",
+                    "dateActe": null,
+                    "actesLegislatifs": {
+                        "acteLegislatif": [
+                            {
+                                "@xsi:type": "RenvoiCMP_Type",
+                                "uid": "L15-VD183438CMPS",
+                                "codeActe": "CMP-SAISIE",
+                                "libelleActe": {
+                                    "nomCanonique": "Convocation d'une CMP",
+                                    "libelleCourt": "Convocation d'une CMP"
+                                },
+                                "organeRef": "PO743571",
+                                "dateActe": "2017-11-21T00:00:00.000+01:00",
+                                "actesLegislatifs": null,
+                                "initiateur": {
+                                    "acteurs": {
+                                        "acteur": {
+                                            "acteurRef": "PA345619",
+                                            "mandatRef": "PM725692"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-VD183438COM",
+                                "codeActe": "CMP-COM",
+                                "libelleActe": {
+                                    "nomCanonique": "Commission Mixte Paritaire",
+                                    "libelleCourt": "Commission Mixte Paritaire"
+                                },
+                                "organeRef": "PO743571",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": [
+                                        {
+                                            "@xsi:type": "NominRapporteurs_Type",
+                                            "uid": "L15-VD183447",
+                                            "codeActe": "CMP-COM-NOMIN",
+                                            "libelleActe": {
+                                                "nomCanonique": "Nomination de rapporteur",
+                                                "libelleCourt": "Nomination de rapporteur"
+                                            },
+                                            "organeRef": "PO743571",
+                                            "dateActe": "2017-11-22T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "rapporteurs": {
+                                                "rapporteur": [
+                                                    {
+                                                        "acteurRef": "PA642788",
+                                                        "typeRapporteur": "rapporteur"
+                                                    },
+                                                    {
+                                                        "acteurRef": "PA227098",
+                                                        "typeRapporteur": "rapporteur"
+                                                    }
+                                                ]
+                                            },
+                                            "reunion": null
+                                        },
+                                        {
+                                            "@xsi:type": "DepotRapport_Type",
+                                            "uid": "L15-VD183449",
+                                            "codeActe": "CMP-COM-RAPPORT-AN",
+                                            "libelleActe": {
+                                                "nomCanonique": "Dépôt du rapport d'une CMP",
+                                                "libelleCourt": "Dépôt du rapport d'une CMP"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-11-22T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "texteAssocie": "RAPPANR5L15B0388",
+                                            "texteAdopte": null
+                                        },
+                                        {
+                                            "@xsi:type": "DepotRapport_Type",
+                                            "uid": "L15-VD183539",
+                                            "codeActe": "CMP-COM-RAPPORT-SN",
+                                            "libelleActe": {
+                                                "nomCanonique": "Dépôt du rapport d'une CMP",
+                                                "libelleCourt": "Dépôt du rapport d'une CMP"
+                                            },
+                                            "organeRef": "PO78718",
+                                            "dateActe": "2017-11-22T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "texteAssocie": "RAPPSNR5S299B0103",
+                                            "texteAdopte": "PRJLSNR5S299BTC0104"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "@xsi:type": "Decision_Type",
+                                "uid": "L15-VD183438DEC",
+                                "codeActe": "CMP-DEC",
+                                "libelleActe": {
+                                    "nomCanonique": "Décision de la CMP",
+                                    "libelleCourt": "Décision de la CMP"
+                                },
+                                "organeRef": "PO743571",
+                                "dateActe": "2017-11-22T00:00:00.000+01:00",
+                                "actesLegislatifs": null,
+                                "statutConclusion": {
+                                    "fam_code": "TCCMP02",
+                                    "libelle": "Désaccord"
+                                },
+                                "reunionRef": null,
+                                "voteRefs": null
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@xsi:type": "Etape_Type",
+                    "uid": "L15-ANNLEC-36030",
+                    "codeActe": "ANNLEC",
+                    "libelleActe": {
+                        "nomCanonique": "Nouvelle Lecture",
+                        "libelleCourt": "Nouvelle lecture"
+                    },
+                    "organeRef": "PO717460",
+                    "dateActe": null,
+                    "actesLegislatifs": {
+                        "acteLegislatif": [
+                            {
+                                "@xsi:type": "DepotInitiativeNavette_Type",
+                                "uid": "L15-VD183436DIN",
+                                "codeActe": "ANNLEC-DEPOT",
+                                "libelleActe": {
+                                    "nomCanonique": "Dépôt d'une initiative en navette",
+                                    "libelleCourt": "Dépôt d'une initiative en navette"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": "2017-11-21T00:00:00.000+01:00",
+                                "actesLegislatifs": null,
+                                "texteAssocie": "PRJLANR5L15B0387",
+                                "provenance": "PO743571"
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-ANNLEC-COM-36030",
+                                "codeActe": "ANNLEC-COM",
+                                "libelleActe": {
+                                    "nomCanonique": "Travaux des commissions",
+                                    "libelleCourt": "Travaux des commissions"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": {
+                                        "@xsi:type": "Etape_Type",
+                                        "uid": "L15-VD183437CF",
+                                        "codeActe": "ANNLEC-COM-FOND",
+                                        "libelleActe": {
+                                            "nomCanonique": "Travaux de la commission saisie au fond",
+                                            "libelleCourt": "Travaux de la commission saisie au fond"
+                                        },
+                                        "organeRef": "PO420120",
+                                        "dateActe": null,
+                                        "actesLegislatifs": {
+                                            "acteLegislatif": [
+                                                {
+                                                    "@xsi:type": "SaisieComFond_Type",
+                                                    "uid": "L15-VD183437CFS",
+                                                    "codeActe": "ANNLEC-COM-FOND-SAISIE",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Renvoi en commission au fond",
+                                                        "libelleCourt": "Renvoi en commission au fond"
+                                                    },
+                                                    "organeRef": "PO420120",
+                                                    "dateActe": "2017-11-21T00:00:00.000+01:00",
+                                                    "actesLegislatifs": null
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD183460R25255",
+                                                    "codeActe": "ANNLEC-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO420120",
+                                                    "dateActe": "2017-11-27T14:00:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC427809",
+                                                    "odjRef": "RUANR5L15S2018IDC427809PT25255"
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD183460R25256",
+                                                    "codeActe": "ANNLEC-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO420120",
+                                                    "dateActe": "2017-11-28T14:30:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC427810",
+                                                    "odjRef": "RUANR5L15S2018IDC427810PT25256"
+                                                },
+                                                {
+                                                    "@xsi:type": "DepotRapport_Type",
+                                                    "uid": "L15-VD183570",
+                                                    "codeActe": "ANNLEC-COM-FOND-RAPPORT",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Dépôt de rapport",
+                                                        "libelleCourt": "Dépôt de rapport"
+                                                    },
+                                                    "organeRef": "PO420120",
+                                                    "dateActe": "2017-11-27T00:00:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "texteAssocie": "RAPPANR5L15B0423",
+                                                    "texteAdopte": null
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-ANNLEC-DEBATS-36030",
+                                "codeActe": "ANNLEC-DEBATS",
+                                "libelleActe": {
+                                    "nomCanonique": "Discussion en séance publique",
+                                    "libelleCourt": "Discussion en séance publique"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": [
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183466S35261",
+                                            "codeActe": "ANNLEC-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-11-28T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20787",
+                                            "odjRef": "RUANR5L15S2018IDS20787PT35261"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183466S35262",
+                                            "codeActe": "ANNLEC-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-11-28T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20788",
+                                            "odjRef": "RUANR5L15S2018IDS20788PT35262"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183466S35275",
+                                            "codeActe": "ANNLEC-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-11-29T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20789",
+                                            "odjRef": "RUANR5L15S2018IDS20789PT35275"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183466S35279",
+                                            "codeActe": "ANNLEC-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-11-29T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20790",
+                                            "odjRef": "RUANR5L15S2018IDS20790PT35279"
+                                        },
+                                        {
+                                            "@xsi:type": "Decision_Type",
+                                            "uid": "L15-VD183597DEC",
+                                            "codeActe": "ANNLEC-DEBATS-DEC",
+                                            "libelleActe": {
+                                                "nomCanonique": "Décision",
+                                                "libelleCourt": "Décision"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-11-29T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "statutConclusion": {
+                                                "fam_code": "TSORTF01",
+                                                "libelle": "adopté"
+                                            },
+                                            "reunionRef": "RUANR5L15S2018IDS20790",
+                                            "voteRefs": null,
+                                            "textesAssocies": {
+                                                "texteAssocie": [
+                                                    {
+                                                        "typeTexte": "BTA",
+                                                        "refTexteAssocie": "PRJLANR5L15BTA0037"
+                                                    },
+                                                    {
+                                                        "typeTexte": "TAP",
+                                                        "refTexteAssocie": "PRJLANR5L15TAP0037"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@xsi:type": "Etape_Type",
+                    "uid": "L15-SNNLEC-36030",
+                    "codeActe": "SNNLEC",
+                    "libelleActe": {
+                        "nomCanonique": "Nouvelle Lecture",
+                        "libelleCourt": "Nouvelle lecture"
+                    },
+                    "organeRef": "PO78718",
+                    "dateActe": null,
+                    "actesLegislatifs": {
+                        "acteLegislatif": [
+                            {
+                                "@xsi:type": "DepotInitiativeNavette_Type",
+                                "uid": "L15-VD183599DIN",
+                                "codeActe": "SNNLEC-DEPOT",
+                                "libelleActe": {
+                                    "nomCanonique": "Dépôt d'une initiative en navette",
+                                    "libelleCourt": "Dépôt d'une initiative en navette"
+                                },
+                                "organeRef": "PO78718",
+                                "dateActe": "2017-11-30T00:00:00.000+01:00",
+                                "actesLegislatifs": null,
+                                "texteAssocie": "PRJLSNR5S299B0121",
+                                "provenance": "PO717460"
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-SNNLEC-COM-36030",
+                                "codeActe": "SNNLEC-COM",
+                                "libelleActe": {
+                                    "nomCanonique": "Travaux des commissions",
+                                    "libelleCourt": "Travaux des commissions"
+                                },
+                                "organeRef": "PO78718",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": {
+                                        "@xsi:type": "Etape_Type",
+                                        "uid": "L15-VD183600CF",
+                                        "codeActe": "SNNLEC-COM-FOND",
+                                        "libelleActe": {
+                                            "nomCanonique": "Travaux de la commission saisie au fond",
+                                            "libelleCourt": "Travaux de la commission saisie au fond"
+                                        },
+                                        "organeRef": "PO211493",
+                                        "dateActe": null,
+                                        "actesLegislatifs": {
+                                            "acteLegislatif": [
+                                                {
+                                                    "@xsi:type": "SaisieComFond_Type",
+                                                    "uid": "L15-VD183600CFS",
+                                                    "codeActe": "SNNLEC-COM-FOND-SAISIE",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Renvoi en commission au fond",
+                                                        "libelleCourt": "Renvoi en commission au fond"
+                                                    },
+                                                    "organeRef": "PO211493",
+                                                    "dateActe": "2017-11-30T00:00:00.000+01:00",
+                                                    "actesLegislatifs": null
+                                                },
+                                                {
+                                                    "@xsi:type": "DepotRapport_Type",
+                                                    "uid": "L15-VD183601",
+                                                    "codeActe": "SNNLEC-COM-FOND-RAPPORT",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Dépôt de rapport",
+                                                        "libelleCourt": "Dépôt de rapport"
+                                                    },
+                                                    "organeRef": "PO211493",
+                                                    "dateActe": "2017-11-30T00:00:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "texteAssocie": "RAPPSNR5S299B0122",
+                                                    "texteAdopte": null
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-SNNLEC-DEBATS-36030",
+                                "codeActe": "SNNLEC-DEBATS",
+                                "libelleActe": {
+                                    "nomCanonique": "Discussion en séance publique",
+                                    "libelleCourt": "Discussion en séance publique"
+                                },
+                                "organeRef": "PO78718",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": [
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183602S35296",
+                                            "codeActe": "SNNLEC-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO78718",
+                                            "dateActe": "2017-12-01T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUSNR5L15S2018IDS20812",
+                                            "odjRef": "RUSNR5L15S2018IDS20812PT35296"
+                                        },
+                                        {
+                                            "@xsi:type": "Decision_Type",
+                                            "uid": "L15-VD183612DEC",
+                                            "codeActe": "SNNLEC-DEBATS-DEC",
+                                            "libelleActe": {
+                                                "nomCanonique": "Décision",
+                                                "libelleCourt": "Décision"
+                                            },
+                                            "organeRef": "PO78718",
+                                            "dateActe": "2017-12-01T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "statutConclusion": {
+                                                "fam_code": "TSORTF07",
+                                                "libelle": "rejeté"
+                                            },
+                                            "reunionRef": "RUSNR5L15S2018IDS20812",
+                                            "voteRefs": null,
+                                            "textesAssocies": {
+                                                "texteAssocie": {
+                                                    "typeTexte": "BTA",
+                                                    "refTexteAssocie": "PRJLSNR5S299BTA0023"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@xsi:type": "Etape_Type",
+                    "uid": "L15-ANLDEF-36030",
+                    "codeActe": "ANLDEF",
+                    "libelleActe": {
+                        "nomCanonique": "Lecture définitive",
+                        "libelleCourt": "Lecture définitive"
+                    },
+                    "organeRef": "PO717460",
+                    "dateActe": null,
+                    "actesLegislatifs": {
+                        "acteLegislatif": [
+                            {
+                                "@xsi:type": "DepotInitiativeNavette_Type",
+                                "uid": "L15-VD183615DIN",
+                                "codeActe": "ANLDEF-DEPOT",
+                                "libelleActe": {
+                                    "nomCanonique": "Dépôt d'une initiative en navette",
+                                    "libelleCourt": "Dépôt d'une initiative en navette"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": "2017-12-01T00:00:00.000+01:00",
+                                "actesLegislatifs": null,
+                                "texteAssocie": "PRJLANR5L15B0434",
+                                "provenance": "PO78718"
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-ANLDEF-COM-36030",
+                                "codeActe": "ANLDEF-COM",
+                                "libelleActe": {
+                                    "nomCanonique": "Travaux des commissions",
+                                    "libelleCourt": "Travaux des commissions"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": {
+                                        "@xsi:type": "Etape_Type",
+                                        "uid": "L15-VD183616CF",
+                                        "codeActe": "ANLDEF-COM-FOND",
+                                        "libelleActe": {
+                                            "nomCanonique": "Travaux de la commission saisie au fond",
+                                            "libelleCourt": "Travaux de la commission saisie au fond"
+                                        },
+                                        "organeRef": "PO420120",
+                                        "dateActe": null,
+                                        "actesLegislatifs": {
+                                            "acteLegislatif": {
+                                                "@xsi:type": "SaisieComFond_Type",
+                                                "uid": "L15-VD183616CFS",
+                                                "codeActe": "ANLDEF-COM-FOND-SAISIE",
+                                                "libelleActe": {
+                                                    "nomCanonique": "Renvoi en commission au fond",
+                                                    "libelleCourt": "Renvoi en commission au fond"
+                                                },
+                                                "organeRef": "PO420120",
+                                                "dateActe": "2017-12-01T00:00:00.000+01:00",
+                                                "actesLegislatifs": null
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-ANLDEF-DEBATS-36030",
+                                "codeActe": "ANLDEF-DEBATS",
+                                "libelleActe": {
+                                    "nomCanonique": "Discussion en séance publique",
+                                    "libelleCourt": "Discussion en séance publique"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": [
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183617S35327",
+                                            "codeActe": "ANLDEF-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-12-04T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20813",
+                                            "odjRef": "RUANR5L15S2018IDS20813PT35327"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183617S35328",
+                                            "codeActe": "ANLDEF-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-12-04T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20814",
+                                            "odjRef": "RUANR5L15S2018IDS20814PT35328"
+                                        },
+                                        {
+                                            "@xsi:type": "Decision_Type",
+                                            "uid": "L15-VD183625DEC",
+                                            "codeActe": "ANLDEF-DEBATS-DEC",
+                                            "libelleActe": {
+                                                "nomCanonique": "Décision",
+                                                "libelleCourt": "Décision"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2017-12-04T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "statutConclusion": {
+                                                "fam_code": "TSORTF01",
+                                                "libelle": "adopté"
+                                            },
+                                            "reunionRef": "RUANR5L15S2018IDS20813",
+                                            "voteRefs": {
+                                                "voteRef": "VTANR5L15V323"
+                                            },
+                                            "textesAssocies": {
+                                                "texteAssocie": [
+                                                    {
+                                                        "typeTexte": "BTA",
+                                                        "refTexteAssocie": "PRJLANR5L15BTA0041"
+                                                    },
+                                                    {
+                                                        "typeTexte": "TAP",
+                                                        "refTexteAssocie": "PRJLANR5L15TAP0041"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@xsi:type": "Etape_Type",
+                    "uid": "L15-CC-36030",
+                    "codeActe": "CC",
+                    "libelleActe": {
+                        "nomCanonique": "Conseil constitutionnel",
+                        "libelleCourt": "Conseil constitutionnel"
+                    },
+                    "organeRef": "PO76034",
+                    "dateActe": null,
+                    "actesLegislatifs": {
+                        "acteLegislatif": [
+                            {
+                                "@xsi:type": "SaisineConseilConstit_Type",
+                                "uid": "L15-VD183733CCS2066",
+                                "codeActe": "CC-SAISIE-AN",
+                                "libelleActe": {
+                                    "nomCanonique": "Saisine du conseil constitutionnel",
+                                    "libelleCourt": "Saisine du conseil constitutionnel"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": "2017-12-07T00:00:00.000+01:00",
+                                "actesLegislatifs": null,
+                                "casSaisine": {
+                                    "fam_code": "TSCCONT05",
+                                    "libelle": "Soixante députés au moins"
+                                },
+                                "initiateurs": null,
+                                "motif": "En application de l'article 61§2 de la Constitution"
+                            },
+                            {
+                                "@xsi:type": "ConclusionEtapeCC_Type",
+                                "uid": "L15-VD183733CCC",
+                                "codeActe": "CC-CONCLUSION",
+                                "libelleActe": {
+                                    "nomCanonique": "Conclusion du conseil constitutionnel",
+                                    "libelleCourt": "Conclusion du conseil constitutionnel"
+                                },
+                                "organeRef": "PO76034",
+                                "dateActe": "2017-12-21T00:00:00.000+01:00",
+                                "actesLegislatifs": null,
+                                "statutConclusion": {
+                                    "fam_code": "TCD02",
+                                    "libelle": "Partiellement conforme"
+                                },
+                                "urlConclusion": "http://www.conseil-constitutionnel.fr/decision/2017/2017756dc.htm",
+                                "numDecision": "756",
+                                "anneeDecision": "2017"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@xsi:type": "Etape_Type",
+                    "uid": "L15-PROM-36030",
+                    "codeActe": "PROM",
+                    "libelleActe": {
+                        "nomCanonique": "Promulgation de la loi",
+                        "libelleCourt": "Promulgation de la loi"
+                    },
+                    "organeRef": "PO717136",
+                    "dateActe": null,
+                    "actesLegislatifs": {
+                        "acteLegislatif": {
+                            "@xsi:type": "Promulgation_Type",
+                            "uid": "L15-VD184033PL",
+                            "codeActe": "PROM-PUB",
+                            "libelleActe": {
+                                "nomCanonique": "Promulgation d'une loi",
+                                "libelleCourt": "Promulgation d'une loi"
+                            },
+                            "organeRef": "PO717136",
+                            "dateActe": "2017-12-30T00:00:00.000+01:00",
+                            "actesLegislatifs": null,
+                            "texteLoiRef": "PRJLANR5L15BTA0041",
+                            "infoJO": {
+                                "typeJO": "JO_LOI_DECRET",
+                                "dateJO": "2017-12-31+01:00",
+                                "pageJO": null,
+                                "numJO": "305",
+                                "urlLegifrance": "http://www.legifrance.gouv.fr/WAspad/UnTexteDeJorf?numjo=CPAX1725580L",
+                                "referenceNOR": "CPAX1725580L"
+                            },
+                            "urlLegifrance": null,
+                            "urlEcheancierLoi": "https://www.legifrance.gouv.fr/affichLoiPubliee.do?idDocument=JORFDOLE000035771815&type=echeancier&typeLoi=&legislature=15",
+                            "codeLoi": "2017-1836",
+                            "titreLoi": "de financement de la sécurité sociale pour 2018"
+                        }
+                    }
+                }
+            ]
+        },
+        "fusionDossier": null
+    }
+}

--- a/aspirateur/tests/sample_data/dossier-DLR5L15N36159.json
+++ b/aspirateur/tests/sample_data/dossier-DLR5L15N36159.json
@@ -1,0 +1,1043 @@
+{
+    "dossierParlementaire": {
+        "@xsi:type": "DossierLegislatif_Type",
+        "uid": "DLR5L15N36159",
+        "legislature": "15",
+        "titreDossier": {
+            "titre": "Fonction publique : un Etat au service d'une société de confiance",
+            "titreChemin": "etat_service_societe_confiance",
+            "senatChemin": "http://www.senat.fr/dossier-legislatif/pjl17-259.html"
+        },
+        "procedureParlementaire": {
+            "code": "1",
+            "libelle": "Projet de loi ordinaire"
+        },
+        "initiateur": {
+            "acteurs": {
+                "acteur": [
+                    {
+                        "acteurRef": "PA345619",
+                        "mandatRef": "PM725692"
+                    },
+                    {
+                        "acteurRef": "PA607846",
+                        "mandatRef": "PM730066"
+                    }
+                ]
+            }
+        },
+        "actesLegislatifs": {
+            "acteLegislatif": [
+                {
+                    "@xsi:type": "Etape_Type",
+                    "uid": "L15-AN1-36159",
+                    "codeActe": "AN1",
+                    "libelleActe": {
+                        "nomCanonique": "1ère lecture (1ère assemblée saisie)",
+                        "libelleCourt": "1ère lecture"
+                    },
+                    "organeRef": "PO717460",
+                    "dateActe": null,
+                    "actesLegislatifs": {
+                        "acteLegislatif": [
+                            {
+                                "@xsi:type": "DepotInitiative_Type",
+                                "uid": "L15-VD183572DI",
+                                "codeActe": "AN1-DEPOT",
+                                "libelleActe": {
+                                    "nomCanonique": "1er dépôt d'une initiative.",
+                                    "libelleCourt": "1er dépôt d'une initiative."
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": "2017-11-27T00:00:00.000+01:00",
+                                "actesLegislatifs": null,
+                                "texteAssocie": "PRJLANR5L15B0424"
+                            },
+                            {
+                                "@xsi:type": "EtudeImpact_Type",
+                                "uid": "L15-VD183572ETI",
+                                "codeActe": "AN1-ETI",
+                                "libelleActe": {
+                                    "nomCanonique": "Etude d'impact",
+                                    "libelleCourt": "Etude d'impact"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": "2017-11-27T00:00:00.000+01:00",
+                                "actesLegislatifs": null,
+                                "contributionInternaute": {
+                                    "dateOuverture": "2017-11-29+01:00",
+                                    "dateFermeture": "2018-02-22+01:00"
+                                },
+                                "texteAssocie": "ETDIANR5L15B0424"
+                            },
+                            {
+                                "@xsi:type": "DepotAvisConseilEtat_Type",
+                                "uid": "L15-VD183572AVCE",
+                                "codeActe": "AN1-AVCE",
+                                "libelleActe": {
+                                    "nomCanonique": "Avis du Conseil d'Etat",
+                                    "libelleCourt": "Avis du Conseil d'Etat"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": "2017-11-27T00:00:00.000+01:00",
+                                "actesLegislatifs": null,
+                                "texteAssocie": "AVCEANR5L15B0424"
+                            },
+                            {
+                                "@xsi:type": "ProcedureAccelere_Type",
+                                "uid": "L15-VD183574",
+                                "codeActe": "AN1-PROCACC",
+                                "libelleActe": {
+                                    "nomCanonique": "Le gouvernement déclare l'urgence / engage la procédure accélérée",
+                                    "libelleCourt": "Le gouvernement déclare l'urgence / engage la procédure accélérée"
+                                },
+                                "organeRef": "PO725688",
+                                "dateActe": "2017-11-27T00:00:00.000+01:00",
+                                "actesLegislatifs": null
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-AN1-COM-36159",
+                                "codeActe": "AN1-COM",
+                                "libelleActe": {
+                                    "nomCanonique": "Travaux des commissions",
+                                    "libelleCourt": "Travaux des commissions"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": {
+                                        "@xsi:type": "Etape_Type",
+                                        "uid": "L15-VD183573CF",
+                                        "codeActe": "AN1-COM-FOND",
+                                        "libelleActe": {
+                                            "nomCanonique": "Travaux de la commission saisie au fond",
+                                            "libelleCourt": "Travaux de la commission saisie au fond"
+                                        },
+                                        "organeRef": "PO744107",
+                                        "dateActe": null,
+                                        "actesLegislatifs": {
+                                            "acteLegislatif": [
+                                                {
+                                                    "@xsi:type": "SaisieComFond_Type",
+                                                    "uid": "L15-VD183573CFS",
+                                                    "codeActe": "AN1-COM-FOND-SAISIE",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Renvoi en commission au fond",
+                                                        "libelleCourt": "Renvoi en commission au fond"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2017-11-27T00:00:00.000+01:00",
+                                                    "actesLegislatifs": null
+                                                },
+                                                {
+                                                    "@xsi:type": "NominRapporteurs_Type",
+                                                    "uid": "L15-VD183779",
+                                                    "codeActe": "AN1-COM-FOND-NOMIN",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Nomination de rapporteur",
+                                                        "libelleCourt": "Nomination de rapporteur"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2017-12-06T00:00:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "rapporteurs": {
+                                                        "rapporteur": {
+                                                            "acteurRef": "PA721498",
+                                                            "typeRapporteur": "rapporteur"
+                                                        }
+                                                    },
+                                                    "reunion": null
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD183777R25316",
+                                                    "codeActe": "AN1-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2017-12-06T16:30:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC428051",
+                                                    "odjRef": "RUANR5L15S2018IDC428051PT25316"
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD183777R25317",
+                                                    "codeActe": "AN1-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2017-12-13T16:30:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC428110",
+                                                    "odjRef": "RUANR5L15S2018IDC428110PT25317"
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD183777R25318",
+                                                    "codeActe": "AN1-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2017-12-20T09:00:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC428111",
+                                                    "odjRef": "RUANR5L15S2018IDC428111PT25318"
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD183777R25320",
+                                                    "codeActe": "AN1-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2017-12-20T16:15:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC428113",
+                                                    "odjRef": "RUANR5L15S2018IDC428113PT25320"
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD183777R25321",
+                                                    "codeActe": "AN1-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2018-01-10T09:30:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC428114",
+                                                    "odjRef": "RUANR5L15S2018IDC428114PT25321"
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD183777R25322",
+                                                    "codeActe": "AN1-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2018-01-15T16:30:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC428115",
+                                                    "odjRef": "RUANR5L15S2018IDC428115PT25322"
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD183777R25334",
+                                                    "codeActe": "AN1-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2018-01-15T21:30:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC428149",
+                                                    "odjRef": "RUANR5L15S2018IDC428149PT25334"
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD183777R25335",
+                                                    "codeActe": "AN1-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2018-01-16T17:00:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC428150",
+                                                    "odjRef": "RUANR5L15S2018IDC428150PT25335"
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD183777R25336",
+                                                    "codeActe": "AN1-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2018-01-16T21:35:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC428151",
+                                                    "odjRef": "RUANR5L15S2018IDC428151PT25336"
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD183777R25384",
+                                                    "codeActe": "AN1-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2018-01-17T10:20:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC428233",
+                                                    "odjRef": "RUANR5L15S2018IDC428233PT25384"
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD183777R25337",
+                                                    "codeActe": "AN1-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2018-01-17T16:25:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC428152",
+                                                    "odjRef": "RUANR5L15S2018IDC428152PT25337"
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD183777R25338",
+                                                    "codeActe": "AN1-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2018-01-17T21:00:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC428153",
+                                                    "odjRef": "RUANR5L15S2018IDC428153PT25338"
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD183777R25422",
+                                                    "codeActe": "AN1-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2018-01-23T14:35:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC428319",
+                                                    "odjRef": "RUANR5L15S2018IDC428319PT25422"
+                                                },
+                                                {
+                                                    "@xsi:type": "DepotRapport_Type",
+                                                    "uid": "L15-VD184144",
+                                                    "codeActe": "AN1-COM-FOND-RAPPORT",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Dépôt de rapport",
+                                                        "libelleCourt": "Dépôt de rapport"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2018-01-18T00:00:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "texteAssocie": "RAPPANR5L15B0575",
+                                                    "texteAdopte": "PRJLANR5L15BTC0575"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-AN1-DEBATS-36159",
+                                "codeActe": "AN1-DEBATS",
+                                "libelleActe": {
+                                    "nomCanonique": "Discussion en séance publique",
+                                    "libelleCourt": "Discussion en séance publique"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": [
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183856S35443",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2018-01-23T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20864",
+                                            "odjRef": "RUANR5L15S2018IDS20864PT35443"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183856S35444",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2018-01-23T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20874",
+                                            "odjRef": "RUANR5L15S2018IDS20874PT35444"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183856S35446",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2018-01-24T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20865",
+                                            "odjRef": "RUANR5L15S2018IDS20865PT35446"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183856S35447",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2018-01-24T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20866",
+                                            "odjRef": "RUANR5L15S2018IDS20866PT35447"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183856S35448",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2018-01-25T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20867",
+                                            "odjRef": "RUANR5L15S2018IDS20867PT35448"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183856S35449",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2018-01-25T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20868",
+                                            "odjRef": "RUANR5L15S2018IDS20868PT35449"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD183856S35488",
+                                            "codeActe": "AN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2018-01-30T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS20886",
+                                            "odjRef": "RUANR5L15S2018IDS20886PT35488"
+                                        },
+                                        {
+                                            "@xsi:type": "Decision_Type",
+                                            "uid": "L15-VD184285DEC",
+                                            "codeActe": "AN1-DEBATS-DEC",
+                                            "libelleActe": {
+                                                "nomCanonique": "Décision",
+                                                "libelleCourt": "Décision"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2018-01-30T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "statutConclusion": {
+                                                "fam_code": "TSORTF01",
+                                                "libelle": "adopté"
+                                            },
+                                            "reunionRef": "RUANR5L15S2018IDS20886",
+                                            "voteRefs": {
+                                                "voteRef": "VTANR5L15V365"
+                                            },
+                                            "textesAssocies": {
+                                                "texteAssocie": [
+                                                    {
+                                                        "typeTexte": "BTA",
+                                                        "refTexteAssocie": "PRJLANR5L15BTA0073"
+                                                    },
+                                                    {
+                                                        "typeTexte": "TAP",
+                                                        "refTexteAssocie": "PRJLANR5L15TAP0073"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@xsi:type": "Etape_Type",
+                    "uid": "L15-SN1-36159",
+                    "codeActe": "SN1",
+                    "libelleActe": {
+                        "nomCanonique": "1ère lecture (2ème assemblée saisie)",
+                        "libelleCourt": "1ère lecture"
+                    },
+                    "organeRef": "PO78718",
+                    "dateActe": null,
+                    "actesLegislatifs": {
+                        "acteLegislatif": [
+                            {
+                                "@xsi:type": "DepotInitiativeNavette_Type",
+                                "uid": "L15-VD184460DIN",
+                                "codeActe": "SN1-DEPOT",
+                                "libelleActe": {
+                                    "nomCanonique": "Dépôt d'une initiative en navette",
+                                    "libelleCourt": "Dépôt d'une initiative en navette"
+                                },
+                                "organeRef": "PO78718",
+                                "dateActe": "2018-01-31T00:00:00.000+01:00",
+                                "actesLegislatifs": null,
+                                "texteAssocie": "PRJLSNR5S299B0259",
+                                "provenance": "PO717460"
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-SN1-COM-36159",
+                                "codeActe": "SN1-COM",
+                                "libelleActe": {
+                                    "nomCanonique": "Travaux des commissions",
+                                    "libelleCourt": "Travaux des commissions"
+                                },
+                                "organeRef": "PO78718",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": {
+                                        "@xsi:type": "Etape_Type",
+                                        "uid": "L15-VD184461CF",
+                                        "codeActe": "SN1-COM-FOND",
+                                        "libelleActe": {
+                                            "nomCanonique": "Travaux de la commission saisie au fond",
+                                            "libelleCourt": "Travaux de la commission saisie au fond"
+                                        },
+                                        "organeRef": "PO748821",
+                                        "dateActe": null,
+                                        "actesLegislatifs": {
+                                            "acteLegislatif": [
+                                                {
+                                                    "@xsi:type": "SaisieComFond_Type",
+                                                    "uid": "L15-VD184461CFS",
+                                                    "codeActe": "SN1-COM-FOND-SAISIE",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Renvoi en commission au fond",
+                                                        "libelleCourt": "Renvoi en commission au fond"
+                                                    },
+                                                    "organeRef": "PO748821",
+                                                    "dateActe": "2018-01-31T00:00:00.000+01:00",
+                                                    "actesLegislatifs": null
+                                                },
+                                                {
+                                                    "@xsi:type": "NominRapporteurs_Type",
+                                                    "uid": "L15-VD184754",
+                                                    "codeActe": "SN1-COM-FOND-NOMIN",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Nomination de rapporteur",
+                                                        "libelleCourt": "Nomination de rapporteur"
+                                                    },
+                                                    "organeRef": "PO748821",
+                                                    "dateActe": "2018-01-31T00:00:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "rapporteurs": {
+                                                        "rapporteur": [
+                                                            {
+                                                                "acteurRef": "PA267081",
+                                                                "typeRapporteur": "rapporteur"
+                                                            },
+                                                            {
+                                                                "acteurRef": "PA703516",
+                                                                "typeRapporteur": "rapporteur"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "reunion": null
+                                                },
+                                                {
+                                                    "@xsi:type": "DepotRapport_Type",
+                                                    "uid": "L15-VD184756",
+                                                    "codeActe": "SN1-COM-FOND-RAPPORT",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Dépôt de rapport",
+                                                        "libelleCourt": "Dépôt de rapport"
+                                                    },
+                                                    "organeRef": "PO748821",
+                                                    "dateActe": "2018-02-22T00:00:00.000+01:00",
+                                                    "actesLegislatifs": null,
+                                                    "texteAssocie": "RAPPSNR5S299B0329",
+                                                    "texteAdopte": "PRJLSNR5S299BTC0330"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-SN1-DEBATS-36159",
+                                "codeActe": "SN1-DEBATS",
+                                "libelleActe": {
+                                    "nomCanonique": "Discussion en séance publique",
+                                    "libelleCourt": "Discussion en séance publique"
+                                },
+                                "organeRef": "PO78718",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": [
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD184753S35726",
+                                            "codeActe": "SN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO78718",
+                                            "dateActe": "2018-03-13T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUSNR5L15S2018IDS20973",
+                                            "odjRef": "RUSNR5L15S2018IDS20973PT35726"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD184753S35727",
+                                            "codeActe": "SN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO78718",
+                                            "dateActe": "2018-03-14T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUSNR5L15S2018IDS20974",
+                                            "odjRef": "RUSNR5L15S2018IDS20974PT35727"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD184753S35730",
+                                            "codeActe": "SN1-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO78718",
+                                            "dateActe": "2018-03-20T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUSNR5L15S2018IDS20976",
+                                            "odjRef": "RUSNR5L15S2018IDS20976PT35730"
+                                        },
+                                        {
+                                            "@xsi:type": "Decision_Type",
+                                            "uid": "L15-VD184942DEC",
+                                            "codeActe": "SN1-DEBATS-DEC",
+                                            "libelleActe": {
+                                                "nomCanonique": "Décision",
+                                                "libelleCourt": "Décision"
+                                            },
+                                            "organeRef": "PO78718",
+                                            "dateActe": "2018-03-20T00:00:00.000+01:00",
+                                            "actesLegislatifs": null,
+                                            "statutConclusion": {
+                                                "fam_code": "TSORTF05",
+                                                "libelle": "modifié"
+                                            },
+                                            "reunionRef": "RUSNR5L15S2018IDS20976",
+                                            "voteRefs": null,
+                                            "textesAssocies": {
+                                                "texteAssocie": {
+                                                    "typeTexte": "BTA",
+                                                    "refTexteAssocie": "PRJLSNR5S299BTA0075"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@xsi:type": "Etape_Type",
+                    "uid": "L15-CMP-36159",
+                    "codeActe": "CMP",
+                    "libelleActe": {
+                        "nomCanonique": "Commission Mixte Paritaire",
+                        "libelleCourt": "Commission Mixte Paritaire"
+                    },
+                    "organeRef": "PO753655",
+                    "dateActe": null,
+                    "actesLegislatifs": {
+                        "acteLegislatif": [
+                            {
+                                "@xsi:type": "RenvoiCMP_Type",
+                                "uid": "L15-VD184992CMPS",
+                                "codeActe": "CMP-SAISIE",
+                                "libelleActe": {
+                                    "nomCanonique": "Convocation d'une CMP",
+                                    "libelleCourt": "Convocation d'une CMP"
+                                },
+                                "organeRef": "PO753655",
+                                "dateActe": "2018-03-21T00:00:00.000+01:00",
+                                "actesLegislatifs": null,
+                                "initiateur": {
+                                    "acteurs": {
+                                        "acteur": {
+                                            "acteurRef": "PA345619",
+                                            "mandatRef": "PM725692"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-VD184992COM",
+                                "codeActe": "CMP-COM",
+                                "libelleActe": {
+                                    "nomCanonique": "Commission Mixte Paritaire",
+                                    "libelleCourt": "Commission Mixte Paritaire"
+                                },
+                                "organeRef": "PO753655",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": [
+                                        {
+                                            "@xsi:type": "NominRapporteurs_Type",
+                                            "uid": "L15-VD185178",
+                                            "codeActe": "CMP-COM-NOMIN",
+                                            "libelleActe": {
+                                                "nomCanonique": "Nomination de rapporteur",
+                                                "libelleCourt": "Nomination de rapporteur"
+                                            },
+                                            "organeRef": "PO753655",
+                                            "dateActe": "2018-04-05T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "rapporteurs": {
+                                                "rapporteur": [
+                                                    {
+                                                        "acteurRef": "PA721498",
+                                                        "typeRapporteur": "rapporteur"
+                                                    },
+                                                    {
+                                                        "acteurRef": "PA267081",
+                                                        "typeRapporteur": "rapporteur"
+                                                    },
+                                                    {
+                                                        "acteurRef": "PA703516",
+                                                        "typeRapporteur": "rapporteur"
+                                                    }
+                                                ]
+                                            },
+                                            "reunion": null
+                                        },
+                                        {
+                                            "@xsi:type": "DepotRapport_Type",
+                                            "uid": "L15-VD185190",
+                                            "codeActe": "CMP-COM-RAPPORT-AN",
+                                            "libelleActe": {
+                                                "nomCanonique": "Dépôt du rapport d'une CMP",
+                                                "libelleCourt": "Dépôt du rapport d'une CMP"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2018-04-05T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "texteAssocie": "RAPPANR5L15B0853",
+                                            "texteAdopte": null
+                                        },
+                                        {
+                                            "@xsi:type": "DepotRapport_Type",
+                                            "uid": "L15-VD185193",
+                                            "codeActe": "CMP-COM-RAPPORT-SN",
+                                            "libelleActe": {
+                                                "nomCanonique": "Dépôt du rapport d'une CMP",
+                                                "libelleCourt": "Dépôt du rapport d'une CMP"
+                                            },
+                                            "organeRef": "PO78718",
+                                            "dateActe": "2018-04-05T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "texteAssocie": "RAPPSNR5S299B0401",
+                                            "texteAdopte": "PRJLSNR5S299BTC0402"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "@xsi:type": "Decision_Type",
+                                "uid": "L15-VD184992DEC",
+                                "codeActe": "CMP-DEC",
+                                "libelleActe": {
+                                    "nomCanonique": "Décision de la CMP",
+                                    "libelleCourt": "Décision de la CMP"
+                                },
+                                "organeRef": "PO753655",
+                                "dateActe": "2018-04-05T00:00:00.000+02:00",
+                                "actesLegislatifs": null,
+                                "statutConclusion": {
+                                    "fam_code": "TCCMP02",
+                                    "libelle": "Désaccord"
+                                },
+                                "reunionRef": null,
+                                "voteRefs": null
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@xsi:type": "Etape_Type",
+                    "uid": "L15-ANNLEC-36159",
+                    "codeActe": "ANNLEC",
+                    "libelleActe": {
+                        "nomCanonique": "Nouvelle Lecture",
+                        "libelleCourt": "Nouvelle lecture"
+                    },
+                    "organeRef": "PO717460",
+                    "dateActe": null,
+                    "actesLegislatifs": {
+                        "acteLegislatif": [
+                            {
+                                "@xsi:type": "DepotInitiativeNavette_Type",
+                                "uid": "L15-VD184959DIN",
+                                "codeActe": "ANNLEC-DEPOT",
+                                "libelleActe": {
+                                    "nomCanonique": "Dépôt d'une initiative en navette",
+                                    "libelleCourt": "Dépôt d'une initiative en navette"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": "2018-03-21T00:00:00.000+01:00",
+                                "actesLegislatifs": null,
+                                "texteAssocie": "PRJLANR5L15B0806",
+                                "provenance": "PO753655"
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-ANNLEC-COM-36159",
+                                "codeActe": "ANNLEC-COM",
+                                "libelleActe": {
+                                    "nomCanonique": "Travaux des commissions",
+                                    "libelleCourt": "Travaux des commissions"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": {
+                                        "@xsi:type": "Etape_Type",
+                                        "uid": "L15-VD184960CF",
+                                        "codeActe": "ANNLEC-COM-FOND",
+                                        "libelleActe": {
+                                            "nomCanonique": "Travaux de la commission saisie au fond",
+                                            "libelleCourt": "Travaux de la commission saisie au fond"
+                                        },
+                                        "organeRef": "PO744107",
+                                        "dateActe": null,
+                                        "actesLegislatifs": {
+                                            "acteLegislatif": [
+                                                {
+                                                    "@xsi:type": "SaisieComFond_Type",
+                                                    "uid": "L15-VD184960CFS",
+                                                    "codeActe": "ANNLEC-COM-FOND-SAISIE",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Renvoi en commission au fond",
+                                                        "libelleCourt": "Renvoi en commission au fond"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2018-03-21T00:00:00.000+01:00",
+                                                    "actesLegislatifs": null
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD185757R25760",
+                                                    "codeActe": "ANNLEC-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2018-06-12T17:00:00.000+02:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC429727",
+                                                    "odjRef": "RUANR5L15S2018IDC429727PT25760"
+                                                },
+                                                {
+                                                    "@xsi:type": "DiscussionCommission_Type",
+                                                    "uid": "L15-VD185757R25761",
+                                                    "codeActe": "ANNLEC-COM-FOND-REUNION",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Réunion de commission",
+                                                        "libelleCourt": "Réunion de commission"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2018-06-12T21:00:00.000+02:00",
+                                                    "actesLegislatifs": null,
+                                                    "reunionRef": "RUANR5L15S2018IDC429728",
+                                                    "odjRef": "RUANR5L15S2018IDC429728PT25761"
+                                                },
+                                                {
+                                                    "@xsi:type": "DepotRapport_Type",
+                                                    "uid": "L15-VD185883",
+                                                    "codeActe": "ANNLEC-COM-FOND-RAPPORT",
+                                                    "libelleActe": {
+                                                        "nomCanonique": "Dépôt de rapport",
+                                                        "libelleCourt": "Dépôt de rapport"
+                                                    },
+                                                    "organeRef": "PO744107",
+                                                    "dateActe": "2018-06-13T00:00:00.000+02:00",
+                                                    "actesLegislatifs": null,
+                                                    "texteAssocie": "RAPPANR5L15B1056",
+                                                    "texteAdopte": "PRJLANR5L15BTC1056"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "@xsi:type": "Etape_Type",
+                                "uid": "L15-ANNLEC-DEBATS-36159",
+                                "codeActe": "ANNLEC-DEBATS",
+                                "libelleActe": {
+                                    "nomCanonique": "Discussion en séance publique",
+                                    "libelleCourt": "Discussion en séance publique"
+                                },
+                                "organeRef": "PO717460",
+                                "dateActe": null,
+                                "actesLegislatifs": {
+                                    "acteLegislatif": [
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD185722S36027",
+                                            "codeActe": "ANNLEC-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2018-06-26T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS21129",
+                                            "odjRef": "RUANR5L15S2018IDS21129PT36027"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD185722S36028",
+                                            "codeActe": "ANNLEC-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2018-06-26T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS21130",
+                                            "odjRef": "RUANR5L15S2018IDS21130PT36028"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD185722S36030",
+                                            "codeActe": "ANNLEC-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2018-06-27T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS21131",
+                                            "odjRef": "RUANR5L15S2018IDS21131PT36030"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD185722S36031",
+                                            "codeActe": "ANNLEC-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2018-06-27T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS21132",
+                                            "odjRef": "RUANR5L15S2018IDS21132PT36031"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD185722S36084",
+                                            "codeActe": "ANNLEC-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2018-06-28T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS21133",
+                                            "odjRef": "RUANR5L15S2018IDS21133PT36084"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD185722S36086",
+                                            "codeActe": "ANNLEC-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2018-06-28T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS21134",
+                                            "odjRef": "RUANR5L15S2018IDS21134PT36086"
+                                        },
+                                        {
+                                            "@xsi:type": "DiscussionSeancePublique_Type",
+                                            "uid": "L15-VD185722S36089",
+                                            "codeActe": "ANNLEC-DEBATS-SEANCE",
+                                            "libelleActe": {
+                                                "nomCanonique": "Discussion en séance publique",
+                                                "libelleCourt": "Discussion en séance publique"
+                                            },
+                                            "organeRef": "PO717460",
+                                            "dateActe": "2018-06-28T00:00:00.000+02:00",
+                                            "actesLegislatifs": null,
+                                            "reunionRef": "RUANR5L15S2018IDS21135",
+                                            "odjRef": "RUANR5L15S2018IDS21135PT36089"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "fusionDossier": null
+    }
+}

--- a/aspirateur/tests/textes/test_get_dossiers_legislatifs.py
+++ b/aspirateur/tests/textes/test_get_dossiers_legislatifs.py
@@ -1,5 +1,6 @@
+import datetime
+import json
 import os
-from datetime import date
 from pathlib import Path
 from unittest.mock import patch
 
@@ -9,87 +10,260 @@ import pytest
 HERE = Path(os.path.dirname(__file__))
 
 
-@pytest.fixture
-def sample_file():
-    path = HERE.parent / "sample_data" / "Dossiers_Legislatifs_XV.json"
-    return path.open()
+DOSSIERS = HERE.parent / "sample_data" / "Dossiers_Legislatifs_XV.json"
 
 
-def test_an_get_dossiers_legislatifs(sample_file):
+@pytest.fixture(scope="module")
+def textes():
+    from zam_aspirateur.textes.dossiers_legislatifs import parse_textes
+
+    with open(DOSSIERS) as f_:
+        data = json.load(f_)
+    return parse_textes(data["export"])
+
+
+@pytest.fixture(scope="module")
+def dossiers():
     from zam_aspirateur.textes.dossiers_legislatifs import get_dossiers_legislatifs
-    from zam_aspirateur.textes.models import Chambre, Lecture, Dossier, Texte, TypeTexte
 
     with patch(
         "zam_aspirateur.textes.dossiers_legislatifs.extract_from_remote_zip"
     ) as m_open:
-        m_open.return_value = sample_file
+        m_open.return_value = DOSSIERS.open()
         dossiers_by_uid = get_dossiers_legislatifs(legislature=15)
 
-    dossiers = list(dossiers_by_uid.values())
+    return dossiers_by_uid
+
+
+def test_number_of_dossiers(dossiers):
     assert len(dossiers) == 605
-    assert dossiers[324] == Dossier(
+
+
+@pytest.fixture
+def dossier_plfss_2018():
+    with open(HERE.parent / "sample_data" / "dossier-DLR5L15N36030.json") as f_:
+        return json.load(f_)["dossierParlementaire"]
+
+
+def test_parse_dossier_plfss_2018(dossier_plfss_2018, textes):
+    from zam_aspirateur.textes.dossiers_legislatifs import parse_dossier
+    from zam_aspirateur.textes.models import Chambre, Lecture, Dossier, Texte, TypeTexte
+
+    dossier = parse_dossier(dossier_plfss_2018, textes)
+    print(dossier)
+
+    assert dossier == Dossier(
         uid="DLR5L15N36030",
         titre="Sécurité sociale : loi de financement 2018",
         lectures={
             "PRJLANR5L15B0269": Lecture(
                 chambre=Chambre.AN,
-                titre="Première lecture",
+                titre="Première lecture – Séance publique",
                 texte=Texte(
                     uid="PRJLANR5L15B0269",
                     type_=TypeTexte.PROJET,
                     numero=269,
                     titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
                     titre_court="PLFSS pour 2018",
-                    date_depot=date(2017, 10, 11),
+                    date_depot=datetime.date(2017, 10, 11),
                 ),
             ),
             "PRJLSNR5S299B0063": Lecture(
                 chambre=Chambre.SENAT,
-                titre="Première lecture",
+                titre="Première lecture – Séance publique",
                 texte=Texte(
                     uid="PRJLSNR5S299B0063",
                     type_=TypeTexte.PROJET,
                     numero=63,
                     titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
                     titre_court="PLFSS pour 2018",
-                    date_depot=date(2017, 11, 6),
+                    date_depot=datetime.date(2017, 11, 6),
                 ),
             ),
             "PRJLANR5L15B0387": Lecture(
                 chambre=Chambre.AN,
-                titre="Nouvelle lecture",
+                titre="Nouvelle lecture – Séance publique",
                 texte=Texte(
                     uid="PRJLANR5L15B0387",
                     type_=TypeTexte.PROJET,
                     numero=387,
                     titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
                     titre_court="PLFSS pour 2018",
-                    date_depot=date(2017, 11, 21),
+                    date_depot=datetime.date(2017, 11, 21),
                 ),
             ),
             "PRJLSNR5S299B0121": Lecture(
                 chambre=Chambre.SENAT,
-                titre="Nouvelle lecture",
+                titre="Nouvelle lecture – Séance publique",
                 texte=Texte(
                     uid="PRJLSNR5S299B0121",
                     type_=TypeTexte.PROJET,
                     numero=121,
                     titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
                     titre_court="PLFSS pour 2018",
-                    date_depot=date(2017, 11, 30),
+                    date_depot=datetime.date(2017, 11, 30),
                 ),
             ),
             "PRJLANR5L15B0434": Lecture(
                 chambre=Chambre.AN,
-                titre="Lecture définitive",
+                titre="Lecture définitive – Séance publique",
                 texte=Texte(
                     uid="PRJLANR5L15B0434",
                     type_=TypeTexte.PROJET,
                     numero=434,
                     titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
                     titre_court="PLFSS pour 2018",
-                    date_depot=date(2017, 12, 1),
+                    date_depot=datetime.date(2017, 12, 1),
                 ),
             ),
         },
     )
+
+
+@pytest.fixture
+def dossier_essoc():
+    with open(HERE.parent / "sample_data" / "dossier-DLR5L15N36159.json") as f_:
+        return json.load(f_)["dossierParlementaire"]
+
+
+def test_parse_dossier_essoc(dossier_essoc, textes):
+    from zam_aspirateur.textes.dossiers_legislatifs import parse_dossier
+    from zam_aspirateur.textes.models import Chambre, Lecture, Dossier, Texte, TypeTexte
+
+    dossier = parse_dossier(dossier_essoc, textes)
+    print(dossier)
+
+    assert dossier == Dossier(
+        uid="DLR5L15N36159",
+        titre="Fonction publique : un Etat au service d'une société de confiance",
+        lectures={
+            "PRJLANR5L15B0424": Lecture(
+                chambre=Chambre.AN,
+                titre="Première lecture – Commission saisie au fond",
+                texte=Texte(
+                    uid="PRJLANR5L15B0424",
+                    type_=TypeTexte.PROJET,
+                    numero=424,
+                    titre_long="projet de loi pour un Etat au service d’une société de confiance",  # noqa
+                    titre_court="Etat service société de confiance",
+                    date_depot=datetime.date(2017, 11, 27),
+                ),
+            ),
+            "PRJLANR5L15BTC0575": Lecture(
+                chambre=Chambre.AN,
+                titre="Première lecture – Séance publique",
+                texte=Texte(
+                    uid="PRJLANR5L15BTC0575",
+                    type_=TypeTexte.PROJET,
+                    numero=575,
+                    titre_long="projet de loi sur le projet de loi, après engagement de la procédure accélérée, pour un Etat au service d’une société de confiance (n°424).",  # noqa
+                    titre_court="Etat service société de confiance",
+                    date_depot=datetime.date(2018, 1, 18),
+                ),
+            ),
+            "PRJLSNR5S299B0259": Lecture(
+                chambre=Chambre.SENAT,
+                titre="Première lecture – Commission saisie au fond",
+                texte=Texte(
+                    uid="PRJLSNR5S299B0259",
+                    type_=TypeTexte.PROJET,
+                    numero=259,
+                    titre_long="projet de loi pour un Etat au service d'une société de confiance",  # noqa
+                    titre_court="État au service d'une société de confiance",
+                    date_depot=datetime.date(2018, 1, 31),
+                ),
+            ),
+            "PRJLSNR5S299BTC0330": Lecture(
+                chambre=Chambre.SENAT,
+                titre="Première lecture – Séance publique",
+                texte=Texte(
+                    uid="PRJLSNR5S299BTC0330",
+                    type_=TypeTexte.PROJET,
+                    numero=330,
+                    titre_long="projet de loi  sur le projet de loi, adopté, par l'Assemblée nationale après engagement de la procédure accélérée, pour un Etat au service d'une société de confiance (n°259).",  # noqa
+                    titre_court="État au service d'une société de confiance",
+                    date_depot=datetime.date(2018, 2, 22),
+                ),
+            ),
+            "PRJLANR5L15B0806": Lecture(
+                chambre=Chambre.AN,
+                titre="Nouvelle lecture – Commission saisie au fond",
+                texte=Texte(
+                    uid="PRJLANR5L15B0806",
+                    type_=TypeTexte.PROJET,
+                    numero=806,
+                    titre_long="projet de loi renforçant l'efficacité de l'administration pour une relation de confiance avec le public",  # noqa
+                    titre_court="Renforcement de l'efficacité de l'administration pour une relation de confiance avec le public",  # noqa
+                    date_depot=datetime.date(2018, 3, 21),
+                ),
+            ),
+            "PRJLANR5L15BTC1056": Lecture(
+                chambre=Chambre.AN,
+                titre="Nouvelle lecture – Séance publique",
+                texte=Texte(
+                    uid="PRJLANR5L15BTC1056",
+                    type_=TypeTexte.PROJET,
+                    numero=1056,
+                    titre_long="projet de loi , en nouvelle lecture, sur le projet de loi, modifié par le Sénat, renforçant l'efficacité de l'administration pour une relation de confiance avec le public (n°806).",  # noqa
+                    titre_court="Renforcement de l'efficacité de l'administration pour une relation de confiance avec le public",  # noqa
+                    date_depot=datetime.date(2018, 6, 13),
+                ),
+            ),
+        },
+    )
+
+
+def test_extract_actes(dossier_essoc):
+    from zam_aspirateur.textes.dossiers_legislatifs import extract_actes
+
+    assert len(extract_actes(dossier_essoc)) == 4
+
+
+def test_gen_lectures(dossier_essoc, textes):
+    from zam_aspirateur.textes.dossiers_legislatifs import (
+        gen_lectures,
+        Chambre,
+        Lecture,
+        Texte,
+        TypeTexte,
+    )
+
+    acte = dossier_essoc["actesLegislatifs"]["acteLegislatif"][0]
+
+    res = list(gen_lectures(acte, textes))
+    assert res == [
+        Lecture(
+            chambre=Chambre.AN,
+            titre="Première lecture – Commission saisie au fond",
+            texte=Texte(
+                uid="PRJLANR5L15B0424",
+                type_=TypeTexte.PROJET,
+                numero=424,
+                titre_long="projet de loi pour un Etat au service d’une société de confiance",  # noqa
+                titre_court="Etat service société de confiance",
+                date_depot=datetime.date(2017, 11, 27),
+            ),
+        ),
+        Lecture(
+            chambre=Chambre.AN,
+            titre="Première lecture – Séance publique",
+            texte=Texte(
+                uid="PRJLANR5L15BTC0575",
+                type_=TypeTexte.PROJET,
+                numero=575,
+                titre_long="projet de loi sur le projet de loi, après engagement de la procédure accélérée, pour un Etat au service d’une société de confiance (n°424).",  # noqa
+                titre_court="Etat service société de confiance",
+                date_depot=datetime.date(2018, 1, 18),
+            ),
+        ),
+    ]
+
+
+def test_walk_actes(dossier_essoc, textes):
+    from zam_aspirateur.textes.dossiers_legislatifs import walk_actes
+
+    acte = dossier_essoc["actesLegislatifs"]["acteLegislatif"][0]
+    assert list(walk_actes(acte)) == [
+        ("COM-FOND", "PRJLANR5L15B0424"),
+        ("DEBATS", "PRJLANR5L15BTC0575"),
+    ]

--- a/aspirateur/tests/textes/test_get_dossiers_legislatifs.py
+++ b/aspirateur/tests/textes/test_get_dossiers_legislatifs.py
@@ -50,7 +50,6 @@ def test_parse_dossier_plfss_2018(dossier_plfss_2018, textes):
     from zam_aspirateur.textes.models import Chambre, Lecture, Dossier, Texte, TypeTexte
 
     dossier = parse_dossier(dossier_plfss_2018, textes)
-    print(dossier)
 
     assert dossier == Dossier(
         uid="DLR5L15N36030",
@@ -131,7 +130,6 @@ def test_parse_dossier_essoc(dossier_essoc, textes):
     from zam_aspirateur.textes.models import Chambre, Lecture, Dossier, Texte, TypeTexte
 
     dossier = parse_dossier(dossier_essoc, textes)
-    print(dossier)
 
     assert dossier == Dossier(
         uid="DLR5L15N36159",

--- a/aspirateur/zam_aspirateur/amendements/fetch_an.py
+++ b/aspirateur/zam_aspirateur/amendements/fetch_an.py
@@ -61,13 +61,9 @@ def fetch_amendement(
 
     content = xmltodict.parse(resp.content)
     amendement = content["amendement"]
-    subdiv_type, subdiv_num, subdiv_mult, subdiv_pos = _parse_subdiv(
-        amendement["division"]["titre"]
+    subdiv_type, subdiv_num, subdiv_mult, subdiv_pos = parse_division(
+        amendement["division"]
     )
-    if amendement["division"]["avantApres"]:
-        subdiv_pos = amendement["division"]["avantApres"].lower()
-        if subdiv_pos == "a":  # TODO: understand what it means...
-            subdiv_pos = ""
     return Amendement(  # type: ignore
         chambre="an",
         session=str(legislature),
@@ -84,6 +80,17 @@ def fetch_amendement(
         dispositif=unjustify(amendement["dispositif"]),
         objet=unjustify(amendement["exposeSommaire"]),
     )
+
+
+def parse_division(division: dict) -> Tuple[str, str, str, str]:
+    if division["type"] == "TITRE":
+        return ("titre", "", "", "")
+    subdiv_type, subdiv_num, subdiv_mult, subdiv_pos = _parse_subdiv(division["titre"])
+    if division["avantApres"]:
+        subdiv_pos = division["avantApres"].lower()
+        if subdiv_pos == "a":  # TODO: understand what it means...
+            subdiv_pos = ""
+    return subdiv_type, subdiv_num, subdiv_mult, subdiv_pos
 
 
 def fetch_amendements(legislature: int, texte: int) -> Tuple[str, List[OrderedDict]]:

--- a/aspirateur/zam_aspirateur/amendements/models.py
+++ b/aspirateur/zam_aspirateur/amendements/models.py
@@ -1,7 +1,7 @@
 import re
 from dataclasses import asdict, dataclass, replace
 from datetime import date
-from typing import Optional, Tuple
+from typing import NamedTuple, Optional, Tuple
 
 
 @dataclass
@@ -101,3 +101,10 @@ class Amendement:
     def asdict(self) -> dict:
         dict_ = asdict(self)  # type: dict
         return dict_
+
+
+class SubDiv(NamedTuple):
+    type_: str
+    num: str
+    mult: str
+    pos: str

--- a/aspirateur/zam_aspirateur/textes/dossiers_legislatifs.py
+++ b/aspirateur/zam_aspirateur/textes/dossiers_legislatifs.py
@@ -118,8 +118,6 @@ def top_level_actes(dossier: dict) -> Iterator[dict]:
 
 def gen_lectures(acte: dict, textes: Dict[str, Texte]) -> Iterator[Lecture]:
     for phase, texte_uid in walk_actes(acte):
-        print(phase)
-
         chambre, titre = TOP_LEVEL_ACTES[acte["codeActe"]]
         if phase == "COM-FOND":
             titre += " – Commission saisie au fond"
@@ -156,7 +154,6 @@ def walk_actes(acte: dict) -> Iterator[Tuple[str, Optional[str]]]:
                     current_texte = TexteRef(
                         acte["codeActe"], acte["@xsi:type"], key, uid
                     )
-                    # print(f"current_texte is now {current_texte}")
 
         for sous_acte in extract_actes(acte):
             yield from _walk_actes(sous_acte)

--- a/aspirateur/zam_aspirateur/textes/models.py
+++ b/aspirateur/zam_aspirateur/textes/models.py
@@ -8,6 +8,9 @@ class Chambre(Enum):
     AN = "an"
     SENAT = "senat"
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}.{self.name}"
+
     def __str__(self) -> str:
         if self.value == "an":
             return "Assemblée nationale"
@@ -19,6 +22,18 @@ class Chambre(Enum):
 class TypeTexte(Enum):
     PROJET = "Projet de loi"
     PROPOSITION = "Proposition de loi"
+
+    @staticmethod
+    def from_dict(texte: dict) -> "TypeTexte":
+        code = texte["classification"]["type"]["code"]
+        if code == "PRJL":
+            return TypeTexte.PROJET
+        if code == "PION":
+            return TypeTexte.PROPOSITION
+        raise ValueError(f"Unknown texte type {code}")
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}.{self.name}"
 
 
 @dataclass

--- a/repondeur/tests/test_lectures_add.py
+++ b/repondeur/tests/test_lectures_add.py
@@ -55,7 +55,7 @@ def test_get_form(app):
         (
             "PRJLANR5L15B0269",
             True,
-            "Assemblée nationale : 1ère lecture (texte nº 269 déposé le 11/10/2017)",
+            "Assemblée nationale – 1ère lecture (texte nº 269 déposé le 11/10/2017)",
         )
     ]
 

--- a/repondeur/zam_repondeur/views/lectures.py
+++ b/repondeur/zam_repondeur/views/lectures.py
@@ -31,7 +31,7 @@ class LecturesAdd:
         self.dossiers_by_uid = get_dossiers_legislatifs(legislature=CURRENT_LEGISLATURE)
         self.lectures_by_dossier = {
             dossier.uid: {
-                lecture.texte.uid: f"{lecture.chambre} : {lecture.titre} (texte nº {lecture.texte.numero} déposé le {lecture.texte.date_depot.strftime('%d/%m/%Y')})"  # noqa
+                lecture.texte.uid: f"{lecture.chambre} – {lecture.titre} (texte nº {lecture.texte.numero} déposé le {lecture.texte.date_depot.strftime('%d/%m/%Y')})"  # noqa
                 for lecture in dossier.lectures.values()
             }
             for dossier in self.dossiers_by_uid.values()

--- a/repondeur/zam_repondeur/views/reponse.py
+++ b/repondeur/zam_repondeur/views/reponse.py
@@ -21,7 +21,7 @@ from zam_repondeur.models import (
 
 
 @view_config(route_name="list_reponses")
-def list_reponses(request: Request) -> dict:
+def list_reponses(request: Request) -> Response:
     lecture = Lecture.get(
         chambre=request.matchdict["chambre"],
         session=request.matchdict["session"],


### PR DESCRIPTION
Dans le formulaire d’ajout d’une lecture, on a maintenant la liste des séances publiques + commissions saisies au fond.

Les numéros de texte pour les séances publiques sont maintenant les bons, donc on peut récupérer les amendements.

Par contre la récupération des amendements pour les commissions ne marche pas, et je ne sais pas encore pourquoi (404 → urls différentes pour les récupérer?)