### PR TITLE
Fix fetching articles content for Assemblée nationale

### DIFF
--- a/repondeur/tests/test_articles_add.py
+++ b/repondeur/tests/test_articles_add.py
@@ -69,6 +69,11 @@ def test_post_form_seance(app, dummy_lecture, dummy_amendements):
 
     responses.add(
         responses.GET,
+        "http://www.assemblee-nationale.fr/15/projets/pl0575.asp",
+        status=404,
+    )
+    responses.add(
+        responses.GET,
         "http://www.assemblee-nationale.fr/15/ta-commission/r0575-a0.asp",
         body=(Path(__file__).parent / "sample_data" / "r0575-a0.html").read_text(
             "utf-8", "ignore"

--- a/repondeur/tests/test_fetch.py
+++ b/repondeur/tests/test_fetch.py
@@ -5,6 +5,31 @@ import pytest
 import responses
 
 
+class TestGetPossibleUrls:
+    def test_assemblee_nationale(self):
+        from zam_repondeur.fetch import get_possible_texte_urls
+        from zam_repondeur.models import Lecture
+
+        lecture = Lecture(
+            chambre="an", session="15", num_texte=269, titre="Titre lecture"
+        )
+        assert get_possible_texte_urls(lecture) == [
+            "http://www.assemblee-nationale.fr/15/projets/pl0269.asp",
+            "http://www.assemblee-nationale.fr/15/ta-commission/r0269-a0.asp",
+        ]
+
+    def test_senat(self):
+        from zam_repondeur.fetch import get_possible_texte_urls
+        from zam_repondeur.models import Lecture
+
+        lecture = Lecture(
+            chambre="senat", session="2017-2018", num_texte=63, titre="Titre lecture"
+        )
+        assert get_possible_texte_urls(lecture) == [
+            "https://www.senat.fr/leg/pjl17-063.html"
+        ]
+
+
 @responses.activate
 def test_get_articles(app, dummy_lecture, dummy_amendements):
     from zam_repondeur.fetch import get_articles


### PR DESCRIPTION
If the case of the Assemblée nationale, the text we want to get the articles of might be:

- the text as initially submitted
- the text as modified by a commission

The URL patterns re different, and the correct one does not depend on whether the lecture is in a commission or in a "séance publique", but on what happened before, and unfortunately we don't keep that information handy.

So the easy way is to just try both URLs in turn, and see which one works...