### PR TITLE
Fix parsing of Assemblée nationale amendement numbers for commissions

### DIFF
--- a/repondeur/tests/models/test_amendement.py
+++ b/repondeur/tests/models/test_amendement.py
@@ -4,36 +4,27 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 
 EXAMPLES = [
-    ("42", 42, 0),
-    ("42 rect.", 42, 1),
-    ("42 rect. bis", 42, 2),
-    ("42 rect. ter", 42, 3),
+    ("", 0, 0, "0"),
+    ("COM-1", 1, 0, "1"),
+    ("COM-48 rect.", 48, 1, "48 rect."),
+    ("CE208", 208, 0, "208"),
+    ("CE|208", 208, 0, "208"),
+    ("42", 42, 0, "42"),
+    ("42 rect.", 42, 1, "42 rect."),
+    ("42 rect. bis", 42, 2, "42 rect. bis"),
+    ("42 rect. ter", 42, 3, "42 rect. ter"),
 ]
 
 
-@pytest.mark.parametrize("text,num,rectif", EXAMPLES)
-def test_parse_num(text, num, rectif):
+@pytest.mark.parametrize("text,num,rectif,disp", EXAMPLES)
+def test_parse_num(text, num, rectif, disp):
     from zam_repondeur.models import Amendement
 
     assert Amendement.parse_num(text) == (num, rectif)
 
 
-@pytest.mark.parametrize("text,num,rectif", [("", 0, 0)])
-def test_parse_num_empty(text, num, rectif):
-    from zam_repondeur.models import Amendement
-
-    assert Amendement.parse_num(text) == (num, rectif)
-
-
-@pytest.mark.parametrize("text,num,rectif", [("COM-1", 1, 0), ("COM-48 rect.", 48, 1)])
-def test_parse_num_commissions(text, num, rectif):
-    from zam_repondeur.models import Amendement
-
-    assert Amendement.parse_num(text) == (num, rectif)
-
-
-@pytest.mark.parametrize("text,num,rectif", EXAMPLES)
-def test_num_disp(lecture_senat, article1_senat, text, num, rectif):
+@pytest.mark.parametrize("text,num,rectif,disp", EXAMPLES)
+def test_num_disp(lecture_senat, article1_senat, text, num, rectif, disp):
     from zam_repondeur.models import Amendement
 
     amendement = Amendement.create(
@@ -45,7 +36,7 @@ def test_num_disp(lecture_senat, article1_senat, text, num, rectif):
         auteur="M. Dupont",
         parent=None,
     )
-    assert amendement.num_disp == text
+    assert amendement.num_disp == disp
 
 
 def test_amendement_parent_relationship(amendements_an):

--- a/repondeur/zam_repondeur/models/amendement.py
+++ b/repondeur/zam_repondeur/models/amendement.py
@@ -151,7 +151,14 @@ class Amendement(Base):  # type: ignore
 
     _SUFFIX_TO_RECTIF = {suffix: rectif for rectif, suffix in _RECTIF_TO_SUFFIX.items()}
 
-    _NUM_RE = re.compile(r"(?P<num>\d+)(?P<rect> rect\.(?: (?P<suffix>\w+))?)?")
+    _NUM_RE = re.compile(
+        r"""
+            (?P<prefix>[A-Z\|\-]*)
+            (?P<num>\d+)
+            (?P<rect>\ rect\.(?:\ (?P<suffix>\w+))?)?
+        """,
+        re.VERBOSE,
+    )
 
     ABANDONED = ("retiré", "irrecevable", "tombé")
 
@@ -159,9 +166,6 @@ class Amendement(Base):  # type: ignore
     def parse_num(text: str) -> Tuple[int, int]:
         if text == "":
             return 0, 0
-        if text.startswith("COM-"):
-            start = len("COM-")
-            text = text[start:]
 
         mo = Amendement._NUM_RE.match(text)
         if mo is None:


### PR DESCRIPTION
We only handled the "COM-" prefix, but it looks like others can be used, so we'll just ignore any leading uppercase letters, "-" and "|".

Fixes: https://rollbar.com/zam/zam/items/25/