### PR TITLE
Fix updating amendements from Assemblée nationale if article changes

### DIFF
--- a/repondeur/tests/fetch/test_fetch_an.py
+++ b/repondeur/tests/fetch/test_fetch_an.py
@@ -302,6 +302,46 @@ def test_fetch_amendement_not_found(lecture_an, app):
         fetch_amendement(lecture=lecture_an, numero=177, position=1)
 
 
+@responses.activate
+def test_fetch_amendement_again(lecture_an, app):
+    from zam_repondeur.fetch.an.amendements import fetch_amendement
+
+    responses.add(
+        responses.GET,
+        build_url(15, 269, 177),
+        body=read_sample_data("an_177.xml"),
+        status=200,
+    )
+
+    amendement1, created = fetch_amendement(lecture=lecture_an, numero=177, position=1)
+    assert created
+
+    amendement2, created = fetch_amendement(lecture=lecture_an, numero=177, position=1)
+    assert not created
+    assert amendement2 is amendement1
+
+
+@responses.activate
+def test_fetch_amendement_again_article_has_changed(lecture_an, app):
+    from zam_repondeur.fetch.an.amendements import fetch_amendement
+
+    responses.add(
+        responses.GET,
+        build_url(15, 269, 177),
+        body=read_sample_data("an_177.xml"),
+        status=200,
+    )
+
+    amendement1, created = fetch_amendement(lecture=lecture_an, numero=177, position=1)
+    assert created
+
+    amendement1.article = None  # let's change the article
+
+    amendement2, created = fetch_amendement(lecture=lecture_an, numero=177, position=1)
+    assert not created
+    assert amendement2 is amendement1
+
+
 @pytest.mark.parametrize(
     "division,type_,num,mult,pos",
     [

--- a/repondeur/zam_repondeur/fetch/an/amendements.py
+++ b/repondeur/zam_repondeur/fetch/an/amendements.py
@@ -119,9 +119,8 @@ def fetch_amendement(
             DBSession,
             Amendement,
             lecture=lecture,
-            article=article,
             num=parent_num,
-            rectif=parent_rectif,
+            create_method_kwargs={"article": article, "rectif": parent_rectif},
         )
     else:
         parent = None
@@ -129,8 +128,8 @@ def fetch_amendement(
         DBSession,
         Amendement,
         lecture=lecture,
-        article=article,
         num=int(amend["numero"]),
+        create_method_kwargs={"article": article},
     )
     amendement.sort = get_sort(amend)
     amendement.position = position


### PR DESCRIPTION
When the article has changed since we first created the amendement, we would fail to find it again, then try to insert it again, causing an `IntegrityError` as the unicity constraint in the database fails.

Fixes: https://rollbar.com/zam/zam/items/26/