### PR TITLE
Fix circular refs when deleting lecture with sous-amendements

### DIFF
--- a/repondeur/zam_repondeur/models/amendement.py
+++ b/repondeur/zam_repondeur/models/amendement.py
@@ -58,7 +58,11 @@ class Amendement(Base):  # type: ignore
     parent_pk = Column(Integer, ForeignKey("amendements.pk"), nullable=True)
     parent_rectif = Column(Integer, nullable=True)
     parent = relationship(
-        "Amendement", uselist=False, remote_side=[pk], backref=backref("children")
+        "Amendement",
+        uselist=False,
+        remote_side=[pk],
+        backref=backref("children"),
+        post_update=True,
     )
     lecture_pk = Column(Integer, ForeignKey("lectures.pk"))
     lecture = relationship("Lecture", back_populates="amendements")

--- a/repondeur/zam_repondeur/views/lectures.py
+++ b/repondeur/zam_repondeur/views/lectures.py
@@ -135,6 +135,7 @@ class LectureView:
     @view_config(request_method="POST")
     def post(self) -> Response:
         DBSession.delete(self.lecture)
+        DBSession.flush()
         self.request.session.flash(
             Message(cls="success", text="Lecture supprimée avec succès.")
         )


### PR DESCRIPTION
For some mysterious reason, some lectures cannot be deleted because of circular references between amendements.

This should not happen, and I have not been able to reproduce it yet, but this fix should prevent the error from happening again.

See: http://docs.sqlalchemy.org/en/latest/orm/relationship_api.html#sqlalchemy.orm.relationship.params.post_update