### PR TITLE
Make worker flush stale locks on startup

### DIFF
--- a/repondeur/zam_repondeur/scripts/worker.py
+++ b/repondeur/zam_repondeur/scripts/worker.py
@@ -42,7 +42,9 @@ def main(argv: List[str] = sys.argv) -> None:
     from zam_repondeur.tasks.fetch import fetch_articles, fetch_amendements  # noqa
     from zam_repondeur.tasks.periodic import update_data, fetch_all_amendements  # noqa
 
-    consumer = huey.create_consumer(worker_type="thread", workers=1, max_delay=5.0)
+    consumer = huey.create_consumer(
+        worker_type="thread", workers=1, max_delay=5.0, flush_locks=True
+    )
     consumer.run()
 
 


### PR DESCRIPTION
In the event the consumer was killed while running a task that held a lock, this ensures that all locks are flushed before starting.

https://github.com/coleifer/huey/blob/7092cf07bc3cf7ca794dec31454142b2a6625a9e/huey/consumer.py#L543-L546