### PR TITLE
Fix inconsistent spelling of "après" in database

### DIFF
--- a/repondeur/db_migrations/versions/4bec591c8da6_fix_inconsistent_spelling_of_apres.py
+++ b/repondeur/db_migrations/versions/4bec591c8da6_fix_inconsistent_spelling_of_apres.py
@@ -1,0 +1,23 @@
+"""Fix inconsistent spelling of apres
+
+Revision ID: 4bec591c8da6
+Revises: 7373c17f2bf1
+Create Date: 2018-10-01 12:54:59.114979
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "4bec591c8da6"
+down_revision = "7373c17f2bf1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("UPDATE articles SET pos='après' WHERE pos='apres';")
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
The parsing of new amendements was fixed in https://github.com/betagouv/zam/pull/137 but this retroactively fixes old values in the DB.