### PR TITLE
Tweak CSV format for better import into Excel 2010

### DIFF
--- a/repondeur/tests/test_writer.py
+++ b/repondeur/tests/test_writer.py
@@ -80,8 +80,11 @@ def test_write_csv(
         DBSession.add_all(amendements)
         nb_rows = write_csv("Titre", amendements, filename, request={})
 
-    with open(filename, "r", encoding="utf-8") as f_:
-        lines = f_.read().splitlines()
+    with open(filename, "r", encoding="utf-8-sig", newline="\n") as f_:
+        lines = [line.rstrip("\n") for line in f_]
+
+    assert not any(line.endswith("\r") for line in lines)
+
     headers, *rows = lines
 
     assert len(rows) == nb_rows == 5
@@ -192,8 +195,11 @@ def test_write_csv_sous_amendement(
         DBSession.add_all(amendements)
         nb_rows = write_csv("Titre", amendements, filename, request={})
 
-    with open(filename, "r", encoding="utf-8") as f_:
-        lines = f_.read().splitlines()
+    with open(filename, "r", encoding="utf-8-sig", newline="\n") as f_:
+        lines = [line.rstrip("\n") for line in f_]
+
+    assert not any(line.endswith("\r") for line in lines)
+
     headers, *rows = lines
 
     assert len(rows) == nb_rows == 5

--- a/repondeur/zam_repondeur/writer.py
+++ b/repondeur/zam_repondeur/writer.py
@@ -78,10 +78,14 @@ def write_csv(
     lecture: Lecture, amendements: Iterable[Amendement], filename: str, request: Request
 ) -> int:
     nb_rows = 0
-    with open(filename, "w", encoding="utf-8") as file_:
+    with open(filename, "w", encoding="utf-8-sig") as file_:
         file_.write(";".join(HEADERS) + "\n")
         writer = csv.DictWriter(
-            file_, fieldnames=FIELDS, delimiter=";", quoting=csv.QUOTE_MINIMAL
+            file_,
+            fieldnames=FIELDS,
+            delimiter=";",
+            quoting=csv.QUOTE_MINIMAL,
+            lineterminator="\n",
         )
         for amendement in amendements:
             writer.writerow(export_amendement(amendement))


### PR DESCRIPTION
- add UTF-8 byte-order mark (BOM) so that Excel properly detects the encoding
- use `"\n"` line terminator instead of the default `"\r\n"` to avoid skipped lines