### PR TITLE
Increase Nginx proxy timeout to 5 minutes for large PDFs

### DIFF
--- a/admin/nginx-https.conf.template
+++ b/admin/nginx-https.conf.template
@@ -51,9 +51,10 @@ server {
 
         client_max_body_size    10m;
         client_body_buffer_size 128k;
-        proxy_connect_timeout   180s;
-        proxy_send_timeout      180s;
-        proxy_read_timeout      180s;
+
+        proxy_connect_timeout   300s;
+        proxy_send_timeout      300s;
+        proxy_read_timeout      300s;
         proxy_buffering         off;
         proxy_temp_file_write_size 128k;
     }


### PR DESCRIPTION
Generating a PDF for a lecture with a large number of amendements can take a long time even on a fast server :-/