### PR TITLE
Use an official wkhtmltopdf build

### DIFF
--- a/admin/fabfile.py
+++ b/admin/fabfile.py
@@ -55,16 +55,21 @@ def put_dir(ctx, local, remote, chown=None):
 
 @task
 def system(ctx):
+    ctx.sudo("curl -L -O https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb")
     ctx.sudo("apt update")
     ctx.sudo(
         "apt install -y {}".format(
             " ".join(
                 [
+                    "git",
+                    "libpq-dev",
+                    "locales",
                     "nginx",
                     "postgresql",
-                    "python3.6",
+                    "python3",
+                    "python3-pip",
                     "redis-server",
-                    "wkhtmltopdf",
+                    "./wkhtmltox_0.12.5-1.bionic_amd64.deb",
                     "xvfb",
                 ]
             )
@@ -231,8 +236,6 @@ def clone_repo(ctx, repo, branch, path, user):
 
 @task
 def install_requirements(ctx, app_dir, user):
-    ctx.sudo("apt-get update")
-    ctx.sudo("apt-get install --yes python3-pip")
     ctx.sudo("python3 -m pip install pipenv==2018.7.1")
     ctx.sudo(f'bash -c "cd {app_dir} && pipenv install"', user=user)
 

--- a/admin/nginx-https.conf.template
+++ b/admin/nginx-https.conf.template
@@ -52,9 +52,9 @@ server {
         client_max_body_size    10m;
         client_body_buffer_size 128k;
 
-        proxy_connect_timeout   300s;
-        proxy_send_timeout      300s;
-        proxy_read_timeout      300s;
+        proxy_connect_timeout   90s;
+        proxy_send_timeout      90s;
+        proxy_read_timeout      90s;
         proxy_buffering         off;
         proxy_temp_file_write_size 128k;
     }

--- a/repondeur/docker/Dockerfile.app
+++ b/repondeur/docker/Dockerfile.app
@@ -1,16 +1,26 @@
-FROM python:3.6.6
+FROM ubuntu:18.04
 
 # Add APT repo for Postgres 10.x
-RUN apt-get update && apt-get install --yes apt-transport-https && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install --yes \
+        curl \
+        apt-transport-https \
+        gnupg \
+    && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
 RUN echo "deb https://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
-RUN apt-get update && apt-get install --yes \
-    libpq-dev \
-    locales \
-    postgresql-client-10 \
-    wkhtmltopdf \
-    xvfb \
+RUN curl -L -O https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb && \
+    apt-get update && \
+    apt-get -f install --yes \
+        git \
+        libpq-dev \
+        locales \
+        postgresql-client-10 \
+        python3 \
+        python3-pip \
+        ./wkhtmltox_0.12.5-1.bionic_amd64.deb \
+        xvfb \
     && rm -rf /var/lib/apt/lists/*
 
 RUN echo 'fr_FR.UTF-8 UTF-8' >> /etc/locale.gen && \
@@ -18,11 +28,15 @@ RUN echo 'fr_FR.UTF-8 UTF-8' >> /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=fr_FR.UTF-8
 
+ENV LC_ALL=fr_FR.UTF-8
+ENV LANG=fr_FR.UTF-8
+
 WORKDIR /app
 
 RUN python3.6 -m pip install pipenv==2018.7.1
 
 COPY . .
+
 RUN pipenv lock -r >requirements.txt && \
     python3.6 -m pip install --src=/src -r requirements.txt && \
     pipenv lock -r --dev >requirements-dev.txt && \


### PR DESCRIPTION
The build in the distro is not the latest, but mostly it does not include some Qt patches, causing some issues:
- slow PDF generation
- excessively large file size
- missing footers and table of contents
- impossibility to select text