### PR TITLE
Improve PDFs exports

### DIFF
--- a/repondeur/tests/test_writer.py
+++ b/repondeur/tests/test_writer.py
@@ -1,9 +1,16 @@
 import transaction
 from datetime import datetime
 
+from pyramid.testing import DummyRequest
+from selectolax.parser import HTMLParser
+
 
 def _csv_row_to_dict(headers, row):
     return dict(zip(headers.split(";"), row.split(";")))
+
+
+def _html_titles_list(parser, selector="h2"):
+    return [node.text().strip() for node in parser.css(selector)]
 
 
 def test_write_csv(
@@ -234,3 +241,342 @@ def test_write_csv_sous_amendement(
         "Commentaires": "",
         "Resume": "",
     }
+
+
+def test_generate_pdf_without_responses(
+    app, lecture_senat, article1_senat, article1av_senat, article7bis_senat
+):
+    from zam_repondeur.writer import generate_html_for_pdf
+    from zam_repondeur.models import DBSession, Amendement
+
+    amendement = Amendement(
+        lecture=lecture_senat,
+        article=article1_senat,
+        alinea="",
+        num=42,
+        rectif=1,
+        auteur="M. DUPONT",
+        groupe="RDSE",
+        matricule="000000",
+        dispositif="<p>L'article 1 est supprimé.</p>",
+        objet="<p>Cet article va à l'encontre du principe d'égalité.</p>",
+        resume="Suppression de l'article",
+        position=1,
+    )
+    amendements = [
+        amendement,
+        Amendement(
+            lecture=lecture_senat,
+            article=article1av_senat,
+            alinea="",
+            num=57,
+            auteur="M. DURAND",
+            groupe="Les Républicains",
+            matricule="000001",
+            objet="baz",
+            dispositif="qux",
+        ),
+        Amendement(
+            lecture=lecture_senat,
+            article=article7bis_senat,
+            alinea="",
+            num=21,
+            auteur="M. MARTIN",
+            groupe=None,
+            matricule="000002",
+            objet="quux",
+            dispositif="quuz",
+        ),
+        Amendement(
+            lecture=lecture_senat,
+            article=article1_senat,
+            alinea="",
+            num=43,
+            auteur="M. JEAN",
+            groupe="Les Indépendants",
+            matricule="000003",
+            objet="corge",
+            dispositif="grault",
+        ),
+        Amendement(
+            lecture=lecture_senat,
+            article=article1_senat,
+            alinea="",
+            num=596,
+            rectif=1,
+            parent=amendement,
+            auteur="M. JEAN",
+            groupe="Les Indépendants",
+            matricule="000003",
+            objet="corge",
+            dispositif="grault",
+        ),
+    ]
+    DBSession.add_all(amendements)
+    parser = HTMLParser(
+        generate_html_for_pdf(DummyRequest(), "print.html", {"lecture": lecture_senat})
+    )
+    assert parser.css_first("h1").text() == "Titre dossier legislatif sénat"
+    assert _html_titles_list(parser) == [
+        "Sénat, session 2017-2018, Séance publique, Numéro lecture, texte nº\xa063",
+        "Article 1",
+        "Article 7 bis",
+    ]
+
+
+def test_generate_pdf_with_amendement_responses(
+    app, lecture_senat, article1_senat, article1av_senat, article7bis_senat
+):
+    from zam_repondeur.writer import generate_html_for_pdf
+    from zam_repondeur.models import DBSession, Amendement
+
+    amendement = Amendement(
+        lecture=lecture_senat,
+        article=article1_senat,
+        alinea="",
+        num=42,
+        rectif=1,
+        auteur="M. DUPONT",
+        groupe="RDSE",
+        matricule="000000",
+        dispositif="<p>L'article 1 est supprimé.</p>",
+        objet="<p>Cet article va à l'encontre du principe d'égalité.</p>",
+        resume="Suppression de l'article",
+        position=1,
+        avis="Favorable",
+    )
+    amendements = [
+        amendement,
+        Amendement(
+            lecture=lecture_senat,
+            article=article1av_senat,
+            alinea="",
+            num=57,
+            auteur="M. DURAND",
+            groupe="Les Républicains",
+            matricule="000001",
+            objet="baz",
+            dispositif="qux",
+        ),
+        Amendement(
+            lecture=lecture_senat,
+            article=article7bis_senat,
+            alinea="",
+            num=21,
+            auteur="M. MARTIN",
+            groupe=None,
+            matricule="000002",
+            objet="quux",
+            dispositif="quuz",
+        ),
+        Amendement(
+            lecture=lecture_senat,
+            article=article1_senat,
+            alinea="",
+            num=43,
+            auteur="M. JEAN",
+            groupe="Les Indépendants",
+            matricule="000003",
+            objet="corge",
+            dispositif="grault",
+        ),
+        Amendement(
+            lecture=lecture_senat,
+            article=article1_senat,
+            alinea="",
+            num=596,
+            rectif=1,
+            parent=amendement,
+            auteur="M. JEAN",
+            groupe="Les Indépendants",
+            matricule="000003",
+            objet="corge",
+            dispositif="grault",
+        ),
+    ]
+    DBSession.add_all(amendements)
+    parser = HTMLParser(
+        generate_html_for_pdf(DummyRequest(), "print.html", {"lecture": lecture_senat})
+    )
+    assert _html_titles_list(parser) == [
+        "Sénat, session 2017-2018, Séance publique, Numéro lecture, texte nº\xa063",
+        "Article 1",
+        "Réponse",
+        "Amendement",
+        "Article 7 bis",
+    ]
+
+
+def test_generate_pdf_with_amendement_and_sous_amendement_responses(
+    app, lecture_senat, article1_senat, article1av_senat, article7bis_senat
+):
+    from zam_repondeur.writer import generate_html_for_pdf
+    from zam_repondeur.models import DBSession, Amendement
+
+    amendement = Amendement(
+        lecture=lecture_senat,
+        article=article1_senat,
+        alinea="",
+        num=42,
+        rectif=1,
+        auteur="M. DUPONT",
+        groupe="RDSE",
+        matricule="000000",
+        dispositif="<p>L'article 1 est supprimé.</p>",
+        objet="<p>Cet article va à l'encontre du principe d'égalité.</p>",
+        resume="Suppression de l'article",
+        position=1,
+        avis="Favorable",
+    )
+    amendements = [
+        amendement,
+        Amendement(
+            lecture=lecture_senat,
+            article=article1av_senat,
+            alinea="",
+            num=57,
+            auteur="M. DURAND",
+            groupe="Les Républicains",
+            matricule="000001",
+            objet="baz",
+            dispositif="qux",
+        ),
+        Amendement(
+            lecture=lecture_senat,
+            article=article7bis_senat,
+            alinea="",
+            num=21,
+            auteur="M. MARTIN",
+            groupe=None,
+            matricule="000002",
+            objet="quux",
+            dispositif="quuz",
+        ),
+        Amendement(
+            lecture=lecture_senat,
+            article=article1_senat,
+            alinea="",
+            num=43,
+            auteur="M. JEAN",
+            groupe="Les Indépendants",
+            matricule="000003",
+            objet="corge",
+            dispositif="grault",
+        ),
+        Amendement(
+            lecture=lecture_senat,
+            article=article1_senat,
+            alinea="",
+            num=596,
+            rectif=1,
+            parent=amendement,
+            auteur="M. JEAN",
+            groupe="Les Indépendants",
+            matricule="000003",
+            objet="corge",
+            dispositif="grault",
+            avis="Défavorable",
+        ),
+    ]
+    DBSession.add_all(amendements)
+    parser = HTMLParser(
+        generate_html_for_pdf(DummyRequest(), "print.html", {"lecture": lecture_senat})
+    )
+    assert _html_titles_list(parser) == [
+        "Sénat, session 2017-2018, Séance publique, Numéro lecture, texte nº\xa063",
+        "Article 1",
+        "Réponse",
+        "Sous-amendement",
+        "Réponse",
+        "Amendement",
+        "Article 7 bis",
+    ]
+
+
+def test_generate_pdf_with_additional_article_amendements_having_responses(
+    app, lecture_senat, article1_senat, article1av_senat, article7bis_senat
+):
+    from zam_repondeur.writer import generate_html_for_pdf
+    from zam_repondeur.models import DBSession, Amendement
+
+    amendement = Amendement(
+        lecture=lecture_senat,
+        article=article1_senat,
+        alinea="",
+        num=42,
+        rectif=1,
+        auteur="M. DUPONT",
+        groupe="RDSE",
+        matricule="000000",
+        dispositif="<p>L'article 1 est supprimé.</p>",
+        objet="<p>Cet article va à l'encontre du principe d'égalité.</p>",
+        resume="Suppression de l'article",
+        position=1,
+        avis="Favorable",
+    )
+    amendements = [
+        amendement,
+        Amendement(
+            lecture=lecture_senat,
+            article=article1av_senat,
+            alinea="",
+            num=57,
+            auteur="M. DURAND",
+            groupe="Les Républicains",
+            matricule="000001",
+            objet="baz",
+            dispositif="qux",
+            avis="Favorable",
+        ),
+        Amendement(
+            lecture=lecture_senat,
+            article=article7bis_senat,
+            alinea="",
+            num=21,
+            auteur="M. MARTIN",
+            groupe=None,
+            matricule="000002",
+            objet="quux",
+            dispositif="quuz",
+        ),
+        Amendement(
+            lecture=lecture_senat,
+            article=article1_senat,
+            alinea="",
+            num=43,
+            auteur="M. JEAN",
+            groupe="Les Indépendants",
+            matricule="000003",
+            objet="corge",
+            dispositif="grault",
+        ),
+        Amendement(
+            lecture=lecture_senat,
+            article=article1_senat,
+            alinea="",
+            num=596,
+            rectif=1,
+            parent=amendement,
+            auteur="M. JEAN",
+            groupe="Les Indépendants",
+            matricule="000003",
+            objet="corge",
+            dispositif="grault",
+            avis="Défavorable",
+        ),
+    ]
+    DBSession.add_all(amendements)
+    parser = HTMLParser(
+        generate_html_for_pdf(DummyRequest(), "print.html", {"lecture": lecture_senat})
+    )
+    assert _html_titles_list(parser) == [
+        "Sénat, session 2017-2018, Séance publique, Numéro lecture, texte nº\xa063",
+        "Réponse",
+        "Amendement",
+        "Article 1",
+        "Réponse",
+        "Sous-amendement",
+        "Réponse",
+        "Amendement",
+        "Article 7 bis",
+    ]

--- a/repondeur/tests/test_writer.py
+++ b/repondeur/tests/test_writer.py
@@ -486,9 +486,9 @@ def test_generate_pdf_with_amendement_and_sous_amendement_responses(
         "Sénat, session 2017-2018, Séance publique, Numéro lecture, texte nº\xa063",
         "Article 1",
         "Réponse",
-        "Sous-amendement",
-        "Réponse",
         "Amendement",
+        "Réponse",
+        "Sous-amendement",
         "Article 7 bis",
     ]
 
@@ -562,7 +562,6 @@ def test_generate_pdf_with_additional_article_amendements_having_responses(
             matricule="000003",
             objet="corge",
             dispositif="grault",
-            avis="Défavorable",
         ),
     ]
     DBSession.add_all(amendements)
@@ -574,8 +573,6 @@ def test_generate_pdf_with_additional_article_amendements_having_responses(
         "Réponse",
         "Amendement",
         "Article 1",
-        "Réponse",
-        "Sous-amendement",
         "Réponse",
         "Amendement",
         "Article 7 bis",

--- a/repondeur/zam_repondeur/models/amendement.py
+++ b/repondeur/zam_repondeur/models/amendement.py
@@ -257,8 +257,10 @@ class Amendement(Base):
     def is_sous_amendement(self) -> bool:
         return self.parent_pk is not None
 
-    def grouped_children(self) -> Iterable[List["Amendement"]]:
-        return self.article.group_amendements(self.children)
+    def grouped_displayable_children(self) -> Iterable[List["Amendement"]]:
+        return self.article.group_amendements(
+            amdt for amdt in self.children if amdt.is_displayable
+        )
 
     @property
     def has_reponse(self) -> bool:

--- a/repondeur/zam_repondeur/templates/print.html
+++ b/repondeur/zam_repondeur/templates/print.html
@@ -17,6 +17,10 @@
       {% endif %}
 
       {% for amendements in article.grouped_displayable_top_level_amendements() %}
+        {{ macros.response_page(amendements) }}
+        {% for amendement in amendements %}
+          {{ macros.amendement_page(amendement) }}
+        {% endfor %}
         {% for amendement in amendements %}
           {% for children_amendements in amendement.grouped_displayable_children() %}
             {{ macros.response_page(children_amendements) }}
@@ -24,10 +28,6 @@
               {{ macros.amendement_page(child) }}
             {% endfor %}
           {% endfor %}
-        {% endfor %}
-        {{ macros.response_page(amendements) }}
-        {% for amendement in amendements %}
-          {{ macros.amendement_page(amendement) }}
         {% endfor %}
       {% endfor %}
 

--- a/repondeur/zam_repondeur/templates/print.html
+++ b/repondeur/zam_repondeur/templates/print.html
@@ -12,11 +12,13 @@
   <main>
     {% for article in lecture.articles|sort %}
 
-      {{ macros.article_page(article) }}
+      {% if not article.pos %}
+        {{ macros.article_page(article) }}
+      {% endif %}
 
       {% for amendements in article.grouped_displayable_top_level_amendements() %}
         {% for amendement in amendements %}
-          {% for children_amendements in amendement.grouped_children() %}
+          {% for children_amendements in amendement.grouped_displayable_children() %}
             {{ macros.response_page(children_amendements) }}
             {% for child in children_amendements %}
               {{ macros.amendement_page(child) }}

--- a/repondeur/zam_repondeur/templates/print_macros.html
+++ b/repondeur/zam_repondeur/templates/print_macros.html
@@ -131,7 +131,7 @@
     <table class="cartouche">
       <tr>
         <td>Article</td>
-        <td>{{ amendement.article }}</td>
+        <td>{{ amendement.article.format(short=True) }}</td>
       </tr>
       {% if amendement.parent %}
         <tr>

--- a/repondeur/zam_repondeur/writer.py
+++ b/repondeur/zam_repondeur/writer.py
@@ -103,11 +103,16 @@ def xvfb_if_supported() -> Generator:
         yield
 
 
+def generate_html_for_pdf(request: Request, template_name: str, context: dict) -> str:
+    """Mostly useful for testing purpose."""
+    env = get_jinja2_environment(request, name=".html")
+    template = env.get_template(template_name)
+    return template.render(**context)
+
+
 def write_pdf(lecture: Lecture, filename: str, request: Request) -> None:
     css = str(STATIC_PATH / "css" / "print.css")
-    env = get_jinja2_environment(request, name=".html")
-    template = env.get_template("print.html")
-    content = template.render(lecture=lecture)
+    content = generate_html_for_pdf(request, "print.html", {"lecture": lecture})
     options = {
         "quiet": "",
         "footer-center": f"{lecture.dossier_legislatif} • Page [page] sur [topage]",
@@ -120,9 +125,7 @@ def write_pdf1(
     lecture: Lecture, amendement: Amendement, filename: str, request: Request
 ) -> None:
     css = str(STATIC_PATH / "css" / "print.css")
-    env = get_jinja2_environment(request, name=".html")
-    template = env.get_template("print1.html")
-    content = template.render(amendement=amendement)
+    content = generate_html_for_pdf(request, "print1.html", {"amendement": amendement})
     options = {
         "quiet": "",
         "footer-center": f"{lecture.dossier_legislatif} • Page [page] sur [topage]",

--- a/repondeur/zam_repondeur/writer.py
+++ b/repondeur/zam_repondeur/writer.py
@@ -107,7 +107,8 @@ def generate_html_for_pdf(request: Request, template_name: str, context: dict) -
     """Mostly useful for testing purpose."""
     env = get_jinja2_environment(request, name=".html")
     template = env.get_template(template_name)
-    return template.render(**context)
+    content: str = template.render(**context)
+    return content
 
 
 def write_pdf(lecture: Lecture, filename: str, request: Request) -> None:


### PR DESCRIPTION
1. add tests
2. restore sous-amendements after parent ones
3. remove (empty) additional article pages