### PR TITLE
Fix broken link to some annexes in PLFSS (Sénat)

### DIFF
--- a/repondeur/db_migrations/versions/4a3b250d356d_make_article_columns_non_nullable.py
+++ b/repondeur/db_migrations/versions/4a3b250d356d_make_article_columns_non_nullable.py
@@ -1,0 +1,26 @@
+"""Make article columns non-nullable
+
+Revision ID: 4a3b250d356d
+Revises: 6756d255959a
+Create Date: 2018-11-08 15:09:36.560536
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "4a3b250d356d"
+down_revision = "6756d255959a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    for col_name in ["type", "num", "mult", "pos"]:
+        op.execute(f"UPDATE articles SET {col_name} = '' WHERE {col_name} IS NULL;")
+        op.alter_column("articles", col_name, nullable=False)
+
+
+def downgrade():
+    for col_name in ["type", "num", "mult", "pos"]:
+        op.alter_column("articles", col_name, nullable=True)

--- a/repondeur/tests/models/test_article.py
+++ b/repondeur/tests/models/test_article.py
@@ -59,6 +59,22 @@ def test_slug(lecture_an, type_, pos, num, mult, output):
 @pytest.mark.parametrize(
     "type_,pos,num,mult,output",
     [
+        ("article", "", "0", "", "article.0.."),
+        ("article", "", "1", "", "article.1.."),
+        ("article", "", "1", "bis", "article.1.bis."),
+        ("annexe", "", "104", "", "annexe.104.."),
+    ],
+)
+def test_url_key(lecture_an, type_, pos, num, mult, output):
+    article = Article.create(
+        lecture=lecture_an, type=type_, num=num, mult=mult, pos=pos
+    )
+    assert article.url_key == output
+
+
+@pytest.mark.parametrize(
+    "type_,pos,num,mult,output",
+    [
         ("article", "", "0", "", "Article liminaire"),
         ("article", "", "1", "", "Article 1"),
         ("annexe", "", "1", "", "Annexe 1"),

--- a/repondeur/zam_repondeur/models/article.py
+++ b/repondeur/zam_repondeur/models/article.py
@@ -45,16 +45,16 @@ class Article(Base):
     __tablename__ = "articles"
     __table_args__ = (UniqueConstraint("lecture_pk", "type", "num", "mult", "pos"),)
 
-    pk = Column(Integer, primary_key=True)
-    lecture_pk = Column(Integer, ForeignKey("lectures.pk"), nullable=False)
-    lecture = relationship(Lecture, back_populates="articles")
-    type = Column(Text, nullable=True)  # type: Optional[str]
-    num = Column(Text, nullable=True)  # type: Optional[str]
-    mult = Column(Text, nullable=True)  # type: Optional[str]
-    pos = Column(Text, nullable=True)  # type: Optional[str]
-    titre = Column(Text, nullable=True)
-    contenu = Column(PickleType, nullable=True)
-    jaune = Column(Text, nullable=True)  # Présentation de l’article.
+    pk: int = Column(Integer, primary_key=True)
+    lecture_pk: int = Column(Integer, ForeignKey("lectures.pk"), nullable=False)
+    lecture: Lecture = relationship(Lecture, back_populates="articles")
+    type: str = Column(Text, nullable=False, default="")
+    num: str = Column(Text, nullable=False, default="")
+    mult: str = Column(Text, nullable=False, default="")
+    pos: str = Column(Text, nullable=False, default="")
+    titre: Optional[str] = Column(Text, nullable=True)
+    contenu: Optional[dict] = Column(PickleType, nullable=True)
+    jaune: Optional[str] = Column(Text, nullable=True)  # Présentation de l’article.
 
     amendements = relationship(
         Amendement,


### PR DESCRIPTION
In some cases we had `None` values for `mult` or `pos`, causing issues when generating the URL key and getting the item from the DB based on the URL key.