### PR TITLE
Optimize Sénat fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,9 @@ wheels/
 pip-log.txt
 pip-delete-this-directory.txt
 
-# Unit test / coverage reports
+# Unit test / profiling / coverage reports
 htmlcov/
+prof/
 .tox/
 .coverage
 .coverage.*

--- a/repondeur/tests/fetch/test_parse.py
+++ b/repondeur/tests/fetch/test_parse.py
@@ -6,6 +6,7 @@ import pytest
 def test_parse_from_csv(lecture_senat):
 
     from zam_repondeur.fetch.senat.amendements import Senat
+    from zam_repondeur.models import DBSession
 
     amend = {
         "Alinéa": " ",
@@ -21,6 +22,8 @@ def test_parse_from_csv(lecture_senat):
         "Subdivision ": "art. add. après Article 7",
         "Url amendement ": "//www.senat.fr/amendements/2017-2018/63/Amdt_1.html",  # noqa
     }
+
+    DBSession.add(lecture_senat)
 
     source = Senat()
     amendement, created = source.parse_from_csv(amend, lecture_senat)

--- a/repondeur/zam_repondeur/clean.py
+++ b/repondeur/zam_repondeur/clean.py
@@ -1,7 +1,6 @@
 from html import unescape
-from typing import Iterable, Optional
 
-import bleach
+from bleach import Cleaner
 
 
 ALLOWED_TAGS = [
@@ -26,9 +25,10 @@ ALLOWED_TAGS = [
 ]
 
 
-def clean_html(html: str, allowed_tags: Optional[Iterable[str]] = None) -> str:
-    if allowed_tags is None:
-        allowed_tags = ALLOWED_TAGS
+CLEANER = Cleaner(tags=ALLOWED_TAGS, strip=True)
+
+
+def clean_html(html: str) -> str:
     text = unescape(html)  # decode HTML entities
-    sanitized: str = bleach.clean(text, tags=allowed_tags, strip=True)
+    sanitized: str = CLEANER.clean(text)
     return sanitized.strip()

--- a/repondeur/zam_repondeur/fetch/an/amendements.py
+++ b/repondeur/zam_repondeur/fetch/an/amendements.py
@@ -12,7 +12,6 @@ from zam_repondeur.fetch.amendements import FetchResult, RemoteSource
 from zam_repondeur.fetch.division import _parse_subdiv
 from zam_repondeur.fetch.exceptions import NotFound
 from zam_repondeur.fetch.http import cached_session
-from zam_repondeur.fetch.division import SubDiv
 from zam_repondeur.models import (
     DBSession,
     Article,
@@ -20,6 +19,8 @@ from zam_repondeur.models import (
     Lecture,
     get_one_or_create,
 )
+from zam_repondeur.models.division import SubDiv
+
 from .division import parse_avant_apres
 
 

--- a/repondeur/zam_repondeur/fetch/an/liasse_xml.py
+++ b/repondeur/zam_repondeur/fetch/an/liasse_xml.py
@@ -14,7 +14,7 @@ from zam_repondeur.fetch.an.dossiers.models import (
     Lecture as LectureRef,
 )
 from zam_repondeur.fetch.dates import parse_date
-from zam_repondeur.fetch.division import _parse_subdiv, SubDiv
+from zam_repondeur.fetch.division import _parse_subdiv
 from zam_repondeur.models import (
     DBSession,
     Article,
@@ -22,6 +22,7 @@ from zam_repondeur.models import (
     Lecture,
     get_one_or_create,
 )
+from zam_repondeur.models.division import SubDiv
 
 from .division import parse_avant_apres
 

--- a/repondeur/zam_repondeur/fetch/division.py
+++ b/repondeur/zam_repondeur/fetch/division.py
@@ -1,16 +1,10 @@
 import logging
 import re
-from typing import NamedTuple
+
+from zam_repondeur.models.division import SubDiv
 
 
 logger = logging.getLogger(__name__)
-
-
-class SubDiv(NamedTuple):
-    type_: str
-    num: str
-    mult: str
-    pos: str
 
 
 SUBDIV_RE = re.compile(

--- a/repondeur/zam_repondeur/fetch/senat/amendements.py
+++ b/repondeur/zam_repondeur/fetch/senat/amendements.py
@@ -16,7 +16,7 @@ from zam_repondeur.fetch.dates import parse_date
 from zam_repondeur.fetch.division import _parse_subdiv
 from zam_repondeur.fetch.exceptions import NotFound
 from zam_repondeur.fetch.senat.senateurs import fetch_and_parse_senateurs, Senateur
-from zam_repondeur.models import Article, Amendement, Lecture, get_one_or_create
+from zam_repondeur.models import Amendement, Lecture
 
 from .derouleur import DiscussionDetails, fetch_and_parse_discussion_details
 
@@ -68,18 +68,10 @@ class Senat(RemoteSource):
 
     def parse_from_csv(self, row: dict, lecture: Lecture) -> Tuple[Amendement, bool]:
         subdiv = _parse_subdiv(row["Subdivision "])
-        article, _ = get_one_or_create(
-            Article,
-            lecture=lecture,
-            type=subdiv.type_,
-            num=subdiv.num,
-            mult=subdiv.mult,
-            pos=subdiv.pos,
-        )
+        article, _ = lecture.find_or_create_article(subdiv)
+
         num, rectif = Amendement.parse_num(row["Numéro "])
-        amendement, created = get_one_or_create(
-            Amendement, create_kwargs={"article": article}, lecture=lecture, num=num
-        )
+        amendement, created = lecture.find_or_create_amendement(num, article)
 
         modified = False
         modified |= self.update_rectif(amendement, rectif)

--- a/repondeur/zam_repondeur/models/division.py
+++ b/repondeur/zam_repondeur/models/division.py
@@ -1,0 +1,8 @@
+from typing import NamedTuple
+
+
+class SubDiv(NamedTuple):
+    type_: str
+    num: str
+    mult: str
+    pos: str


### PR DESCRIPTION
I looked into which tests were slow, and the worst offender was `tests/fetch/test_fetch_senat.py::test_aspire_senat_plf2019_1re_partie` with ~27s on my computer.

I then did some profiling to understand where time was being spent:
<img width="1552" alt="capture d ecran 2019-01-29 a 13 14 46" src="https://user-images.githubusercontent.com/321872/51991369-4361c800-24ab-11e9-9724-e942e25deca0.png">

The biggest one is `get_one_or_create`, which does a `SELECT` query to the database each time, additionally causing an automatic session flush if we added some objects to the session.

I refactored the fetch logic to avoid doing queries and doing the article/amendement lookup Python-side by iterating on the relationship from the lecture object.

This brings a significant speed improvement:
<img width="1552" alt="capture d ecran 2019-01-30 a 16 55 52" src="https://user-images.githubusercontent.com/321872/51994195-94c08600-24b0-11e9-8593-0652cf470a56.png">

Most of the time is then spent in the HTML cleaning.

I was able to reduce it a little by using a global `Cleaner` object to avoid paying the initialization cost on each call:
<img width="1552" alt="capture d ecran 2019-01-30 a 16 58 55" src="https://user-images.githubusercontent.com/321872/51994205-9a1dd080-24b0-11e9-939d-e9d8647d8a1d.png">

The remaining time is spent parsing the HTML with html5lib and serializing it again.

I tried using the `html-sanitizer` library instead of `bleach`, as it is based on `lxml`. The speed is better, but the behaviour is a bit different, so I preferred not to include that change in this PR.
