### PR TITLE
Fix custom transfers and required fields

### DIFF
--- a/repondeur/tests/test_lecture_transfer.py
+++ b/repondeur/tests/test_lecture_transfer.py
@@ -18,7 +18,6 @@ def test_lecture_get_transfer_amendements(
     assert resp.forms["transfer-amendements"].method == "POST"
     assert list(resp.forms["transfer-amendements"].fields.keys()) == [
         "nums",
-        "submit-table",
         "target",
         "submit",
     ]
@@ -27,6 +26,12 @@ def test_lecture_get_transfer_amendements(
         ("", True, ""),
         ("ronan@example.com", False, "Ronan (ronan@example.com)"),
     ]
+    assert resp.forms["transfer-amendements-custom"].method == "POST"
+    assert list(resp.forms["transfer-amendements-custom"].fields.keys()) == [
+        "nums",
+        "submit-table",
+    ]
+    assert resp.forms["transfer-amendements-custom"].fields["nums"][0].value == "666"
 
 
 def test_lecture_get_transfer_amendements_from_me(
@@ -50,7 +55,6 @@ def test_lecture_get_transfer_amendements_from_me(
     assert resp.forms["transfer-amendements"].method == "POST"
     assert list(resp.forms["transfer-amendements"].fields.keys()) == [
         "nums",
-        "submit-index",
         "target",
         "submit",
     ]
@@ -59,6 +63,12 @@ def test_lecture_get_transfer_amendements_from_me(
         ("", True, ""),
         ("ronan@example.com", False, "Ronan (ronan@example.com)"),
     ]
+    assert resp.forms["transfer-amendements-custom"].method == "POST"
+    assert list(resp.forms["transfer-amendements-custom"].fields.keys()) == [
+        "nums",
+        "submit-index",
+    ]
+    assert resp.forms["transfer-amendements-custom"].fields["nums"][0].value == "666"
 
 
 def test_lecture_get_transfer_amendements_from_other(
@@ -81,8 +91,6 @@ def test_lecture_get_transfer_amendements_from_other(
     assert resp.forms["transfer-amendements"].method == "POST"
     assert list(resp.forms["transfer-amendements"].fields.keys()) == [
         "nums",
-        "submit-table",
-        "submit-index",
         "target",
         "submit",
     ]
@@ -91,6 +99,13 @@ def test_lecture_get_transfer_amendements_from_other(
         ("", True, ""),
         ("ronan@example.com", False, "Ronan (ronan@example.com)"),
     ]
+    assert resp.forms["transfer-amendements-custom"].method == "POST"
+    assert list(resp.forms["transfer-amendements-custom"].fields.keys()) == [
+        "nums",
+        "submit-table",
+        "submit-index",
+    ]
+    assert resp.forms["transfer-amendements-custom"].fields["nums"][0].value == "666"
 
 
 def test_lecture_post_transfer_amendements_to_me(
@@ -108,7 +123,7 @@ def test_lecture_post_transfer_amendements_to_me(
         {"nums": [amendements_an[0]]},
         user=user_david.email,
     )
-    resp = resp.forms["transfer-amendements"].submit("submit-table")
+    resp = resp.forms["transfer-amendements-custom"].submit("submit-table")
     assert resp.status_code == 302
     assert (
         resp.location
@@ -142,7 +157,7 @@ def test_lecture_post_transfer_amendements_to_index(
         {"nums": [amendements_an[0]]},
         user=user_david.email,
     )
-    resp = resp.forms["transfer-amendements"].submit("submit-index")
+    resp = resp.forms["transfer-amendements-custom"].submit("submit-index")
     assert resp.status_code == 302
     assert resp.location == "https://zam.test/lectures/an.15.269.PO717460/amendements"
     user_david = DBSession.query(User).filter(User.email == user_david.email).first()
@@ -178,7 +193,7 @@ def test_lecture_post_transfer_amendements_to_other(
     )
     form = resp.forms["transfer-amendements"]
     form["target"] = user_ronan.email
-    resp = form.submit("submit")
+    resp = form.submit()
     assert resp.status_code == 302
     assert resp.location == "https://zam.test/lectures/an.15.269.PO717460/amendements"
     user_david = DBSession.query(User).filter(User.email == user_david.email).first()

--- a/repondeur/zam_repondeur/templates/transfer_amendements.html
+++ b/repondeur/zam_repondeur/templates/transfer_amendements.html
@@ -4,22 +4,16 @@
     <link rel="stylesheet" href="{{ request.static_url('zam_repondeur:static/selectize/css/selectize.css') }}">
     <link rel="stylesheet" href="{{ request.static_url('zam_repondeur:static/selectize/css/selectize.bootstrap3.css') }}">
     <style type="text/css">
+        h3.line-through {
+            margin: 3rem auto;
+            width: 40rem;
+        }
         form {
             width: 40rem;
             margin: 0 auto;
         }
             form * {
                 width: 100%;
-            }
-            form h2 {
-                margin: 2.5rem 0;
-                font-weight: 600;
-                text-align: center;
-            }
-            form h3 {
-                margin: 3rem 0;
-                font-weight: 600;
-                text-align: center;
             }
             form label {
                 display: block;
@@ -53,28 +47,35 @@
 {% endblock %}
 
 {% block body %}
-    <form id="transfer-amendements" action="{{ request.resource_url(context['tables'], request.user.email) }}" method="POST">
-        <h2>
-            Transférer
-            {% if amendements|length > 1 %}
-                les amendements
-            {% else %}
-                l’amendement
-            {% endif %}
-            {% for amendement in amendements %}
-                <a href="{{ request.resource_url(context['amendements'][amendement.num_str], 'amendement_edit') }}">{{ amendement }}</a>{% if loop.revindex == 2 %} et {% else %}{% if not loop.last %}, {% endif %}{% endif %}
-                <input type="hidden" name="nums" value="{{ amendement.num }}">
-            {% endfor %}
-        </h2>
+    <h1>
+        Transférer
+        {% if amendements|length > 1 %}
+            les amendements
+        {% else %}
+            l’amendement
+        {% endif %}
+        {% for amendement in amendements %}
+            <a href="{{ request.resource_url(context['amendements'][amendement.num_str], 'amendement_edit') }}">{{ amendement }}</a>{% if loop.revindex == 2 %} et {% else %}{% if not loop.last %}, {% endif %}{% endif %}
+        {% endfor %}
+    </h1>
+    <form id="transfer-amendements-custom" action="{{ request.resource_url(context['tables'], request.user.email) }}" method="POST">
+        {% for amendement in amendements %}
+            <input type="hidden" name="nums" value="{{ amendement.num }}">
+        {% endfor %}
         <div>
             {% if show_transfer_to_myself %}
                 <input type="submit" name="submit-table" value="Transférer sur ma table" class="button primary enabled">
             {% endif %}
             {% if show_transfer_to_index %}
-                <input type="submit" name="submit-index" value="Transférer à l’index" class="button primary">
+                <input type="submit" name="submit-index" value="Transférer à l’index" class="button primary {% if not show_transfer_to_myself %}enabled{% endif %}">
             {% endif %}
         </div>
-        <h3 class="line-through">ou</h3>
+    </form>
+    <h3 class="line-through">ou</h3>
+    <form id="transfer-amendements" action="{{ request.resource_url(context['tables'], request.user.email) }}" method="POST">
+        {% for amendement in amendements %}
+            <input type="hidden" name="nums" value="{{ amendement.num }}">
+        {% endfor %}
         <div>
             <label for="target">Destinataire :</label>
             <select id="target" name="target" required>


### PR DESCRIPTION
Previously the shared form for both actions cannot be submitted because a field is required only in one case. Now splitted into two distinct forms.