### PR TITLE
Add a lock to Redis global data structures

### DIFF
--- a/repondeur/requirements.txt
+++ b/repondeur/requirements.txt
@@ -51,6 +51,7 @@ pyramid==1.10.1
 python-dateutil==2.7.5
 python-editor==1.0.3
 python-gitlab==1.5.1        # the-law-factory-parser: == 1.5.1
+python-redis-lock==3.3.1
 pytz==2018.9
 redis==3.0.1
 regex==2018.8.29            # dateparser

--- a/repondeur/setup.py
+++ b/repondeur/setup.py
@@ -16,6 +16,7 @@ requires = [
     "pyramid-jinja2",
     "pyramid_retry",
     "pyramid_tm",
+    "python-redis-lock",
     "redis",
     "requests",
     "rollbar",

--- a/repondeur/tests/conftest.py
+++ b/repondeur/tests/conftest.py
@@ -81,12 +81,7 @@ def db():
 def data_repository():
     from zam_repondeur.data import repository
 
-    repository.clear_data()
     repository.load_data()
-
-    yield
-
-    repository.clear_data()
 
 
 @pytest.fixture

--- a/repondeur/zam_repondeur/data.py
+++ b/repondeur/zam_repondeur/data.py
@@ -3,6 +3,7 @@ from typing import Dict, List
 
 from pyramid.config import Configurator
 from redis import Redis
+from redis_lock import Lock
 
 from zam_repondeur.fetch.an.dossiers.dossiers_legislatifs import (
     get_dossiers_legislatifs
@@ -17,7 +18,6 @@ def includeme(config: Configurator) -> None:
     Called automatically via config.include("zam_repondeur.data")
     """
     init_repository(config.registry.settings)
-    repository.clear_data()
     repository.load_data()
 
 
@@ -31,31 +31,32 @@ def init_repository(settings: Dict[str, str]) -> None:
 class DataRepository:
     """
     Store and access global data in Redis
+
+    We use a lock so that periodic updates by a worker thread do not interfere
+    with regular read accesses (e.g. when fetching amendements).
     """
 
     def __init__(self) -> None:
         self.initialized = True
 
     def initialize(self, redis_url: str, legislatures: List[int]) -> None:
-        self.connection = Redis.from_url(redis_url)
         self.legislatures = legislatures
+        self.connection = Redis.from_url(redis_url)
         self.initialized = True
-
-    @needs_init
-    def clear_data(self) -> None:
-        self.connection.flushdb()
 
     @needs_init
     def load_data(self) -> None:
         dossiers = get_dossiers_legislatifs(*self.legislatures)
         organes, acteurs = get_organes_acteurs()
-        self.connection.set("dossiers", pickle.dumps(dossiers))
-        self.connection.set("organes", pickle.dumps(organes))
-        self.connection.set("acteurs", pickle.dumps(acteurs))
+        with Lock(self.connection, "data"):
+            self.connection.set("dossiers", pickle.dumps(dossiers))
+            self.connection.set("organes", pickle.dumps(organes))
+            self.connection.set("acteurs", pickle.dumps(acteurs))
 
     @needs_init
     def get_data(self, key: str) -> dict:
-        raw_bytes = self.connection.get(key)
+        with Lock(self.connection, "data"):
+            raw_bytes = self.connection.get(key)
         if raw_bytes is None:
             return {}
 

--- a/repondeur/zam_repondeur/scripts/worker.py
+++ b/repondeur/zam_repondeur/scripts/worker.py
@@ -9,7 +9,7 @@ from redis.exceptions import ConnectionError
 from sqlalchemy import engine_from_config
 
 from zam_repondeur import BASE_SETTINGS
-from zam_repondeur.data import init_repository
+from zam_repondeur.data import init_repository, repository
 from zam_repondeur.errors import extract_settings, setup_rollbar_log_handler
 from zam_repondeur.models import DBSession
 from zam_repondeur.tasks.huey import init_huey
@@ -45,6 +45,7 @@ def main(argv: List[str] = sys.argv) -> None:
     DBSession.configure(bind=engine)
 
     init_repository(settings)
+    repository.load_data()
 
     huey = init_huey(settings)
 

--- a/repondeur/zam_repondeur/tasks/periodic.py
+++ b/repondeur/zam_repondeur/tasks/periodic.py
@@ -1,8 +1,9 @@
 """
 NB: make sure tasks.huey.init_huey() has been called before importing this module
 """
-import transaction
+import logging
 
+import transaction
 from huey import crontab
 
 from zam_repondeur.tasks.huey import huey
@@ -10,12 +11,17 @@ from zam_repondeur.models import DBSession, Lecture
 from zam_repondeur.tasks.fetch import fetch_amendements
 
 
+logger = logging.getLogger(__name__)
+
+
 # TODISCUSS: hourly? daily?
 @huey.periodic_task(crontab(minute="1", hour="*"))
 def update_data() -> None:
     from zam_repondeur.data import repository
 
+    logger.info("Data update start")
     repository.load_data()
+    logger.info("Data update end")
 
 
 # Keep it last as it takes time and will add up with the growing number of lectures.


### PR DESCRIPTION
This prevents periodic updates by a worker thread from interfering with regular read accesses (e.g. when fetching amendements).

This should fix intermittent `OrganeNotFound` errors observed in production.