### PR TITLE
Turn fetched dataclasses into regular models

### DIFF
--- a/repondeur/tests/fetch/test_fetch_an.py
+++ b/repondeur/tests/fetch/test_fetch_an.py
@@ -154,23 +154,17 @@ class TestFetchAndParseAll:
         assert errored == []
 
     @responses.activate
-    def test_sous_amendements(self, app, source):
-        from zam_repondeur.models import DBSession, Lecture
+    def test_sous_amendements(self, app, source, lecture_an):
+        from zam_repondeur.models import DBSession
 
         with transaction.manager:
-            lecture = Lecture.create(
-                chambre="an",
-                session="15",
-                num_texte=911,
-                titre="Titre lecture",
-                organe="PO717460",
-                dossier_legislatif="Titre dossier legislatif",
-            )
+            lecture_an.texte.numero = 911
+            DBSession.add(lecture_an)
 
-        DBSession.add(lecture)
+        DBSession.add(lecture_an)
 
         with setup_mock_responses(
-            lecture=lecture,
+            lecture=lecture_an,
             liste=read_sample_data("an/911/liste.xml"),
             amendements=(
                 ("1", read_sample_data("an/911/1.xml")),
@@ -178,7 +172,7 @@ class TestFetchAndParseAll:
                 ("3", read_sample_data("an/911/3.xml")),
             ),
         ):
-            amendements, created, errored = source.fetch(lecture=lecture)
+            amendements, created, errored = source.fetch(lecture=lecture_an)
 
         assert len(amendements) == 3
 

--- a/repondeur/tests/fetch/test_fetch_senat.py
+++ b/repondeur/tests/fetch/test_fetch_senat.py
@@ -170,20 +170,15 @@ def test_aspire_senat_again_with_irrecevable(app, lecture_senat):
 
 
 @responses.activate
-def test_aspire_senat_plf2019_1re_partie(app):
+def test_aspire_senat_plf2019_1re_partie(app, lecture_senat):
     from zam_repondeur.fetch.senat.amendements import Senat
-    from zam_repondeur.models import DBSession, Lecture
+    from zam_repondeur.models import DBSession
 
     with transaction.manager:
-        lecture = Lecture.create(
-            chambre="senat",
-            session="2018-2019",
-            num_texte=146,
-            partie=1,
-            titre="Numéro lecture – Titre lecture sénat",
-            organe="PO78718",
-            dossier_legislatif="Titre dossier legislatif sénat",
-        )
+        lecture_senat.texte.numero = 146
+        lecture_senat.partie = 1
+        lecture_senat.session = "2018-2019"
+        DBSession.add(lecture_senat)
 
     sample_data = read_sample_data("jeu_complet_2018-2019_146.csv")
 
@@ -212,31 +207,26 @@ def test_aspire_senat_plf2019_1re_partie(app):
         status=200,
     )
 
-    DBSession.add(lecture)
+    DBSession.add(lecture_senat)
 
     source = Senat()
 
-    amendements, created, errored = source.fetch(lecture)
+    amendements, created, errored = source.fetch(lecture_senat)
 
     # All amendements from part 1 are fetched
     assert len(amendements) == 1005
 
 
 @responses.activate
-def test_aspire_senat_plf2019_2e_partie(app):
+def test_aspire_senat_plf2019_2e_partie(app, lecture_senat):
     from zam_repondeur.fetch.senat.amendements import Senat
-    from zam_repondeur.models import DBSession, Lecture
+    from zam_repondeur.models import DBSession
 
     with transaction.manager:
-        lecture = Lecture.create(
-            chambre="senat",
-            session="2018-2019",
-            num_texte=146,
-            partie=2,
-            titre="Numéro lecture – Titre lecture sénat",
-            organe="PO78718",
-            dossier_legislatif="Titre dossier legislatif sénat",
-        )
+        lecture_senat.texte.numero = 146
+        lecture_senat.partie = 2
+        lecture_senat.session = "2018-2019"
+        DBSession.add(lecture_senat)
 
     sample_data = read_sample_data("jeu_complet_2018-2019_146.csv")
 
@@ -281,11 +271,11 @@ def test_aspire_senat_plf2019_2e_partie(app):
             status=404,
         )
 
-    DBSession.add(lecture)
+    DBSession.add(lecture_senat)
 
     source = Senat()
 
-    amendements, created, errored = source.fetch(lecture)
+    amendements, created, errored = source.fetch(lecture_senat)
 
     # All amendements from part 2 are fetched
     assert len(amendements) == 35
@@ -437,7 +427,7 @@ def test_fetch_all_commission(lecture_senat):
     from zam_repondeur.models import DBSession
 
     with transaction.manager:
-        lecture_senat.num_texte = 583
+        lecture_senat.texte.numero = 583
         DBSession.add(lecture_senat)
 
     sample_data = read_sample_data("jeu_complet_commission_2017-2018_583.csv")
@@ -502,7 +492,7 @@ def test_fetch_discussion_details(lecture_senat):
 
     with transaction.manager:
         lecture_senat.session = "2016-2017"
-        lecture_senat.num_texte = 610
+        lecture_senat.texte.numero = 610
         DBSession.add(lecture_senat)
 
     json_data = json.loads(read_sample_data("liste_discussion_610.json"))
@@ -559,40 +549,32 @@ def test_derouleur_urls(lecture_senat):
     ]
 
 
-def test_derouleur_urls_plf2019_1re_partie():
+def test_derouleur_urls_plf2019_1re_partie(lecture_senat):
     from zam_repondeur.fetch.senat.derouleur import derouleur_urls
-    from zam_repondeur.models import Lecture
+    from zam_repondeur.models import DBSession
 
-    lecture = Lecture.create(
-        chambre="senat",
-        session="2018-2019",
-        num_texte=146,
-        partie=1,
-        titre="Première lecture – Séance publique (1re partie)",
-        organe="PO78718",
-        dossier_legislatif="Budget : loi de finances 2019",
-    )
+    with transaction.manager:
+        lecture_senat.texte.numero = 146
+        lecture_senat.partie = 1
+        lecture_senat.session = "2018-2019"
+        DBSession.add(lecture_senat)
 
-    assert list(derouleur_urls(lecture, "seance")) == [
+    assert list(derouleur_urls(lecture_senat, "seance")) == [
         "https://www.senat.fr/enseance/2018-2019/146/liste_discussion_103393.json"
     ]
 
 
-def test_derouleur_urls_plf2019_2e_partie():
+def test_derouleur_urls_plf2019_2e_partie(lecture_senat):
     from zam_repondeur.fetch.senat.derouleur import derouleur_urls
-    from zam_repondeur.models import Lecture
+    from zam_repondeur.models import DBSession
 
-    lecture = Lecture.create(
-        chambre="senat",
-        session="2018-2019",
-        num_texte=146,
-        partie=2,
-        titre="Première lecture – Séance publique (2e partie)",
-        organe="PO78718",
-        dossier_legislatif="Budget : loi de finances 2019",
-    )
+    with transaction.manager:
+        lecture_senat.texte.numero = 146
+        lecture_senat.partie = 2
+        lecture_senat.session = "2018-2019"
+        DBSession.add(lecture_senat)
 
-    urls = list(derouleur_urls(lecture, "seance"))
+    urls = list(derouleur_urls(lecture_senat, "seance"))
     assert len(urls) > 1
     assert (
         urls[0]

--- a/repondeur/tests/fetch/test_get_dossiers_legislatifs.py
+++ b/repondeur/tests/fetch/test_get_dossiers_legislatifs.py
@@ -1,40 +1,10 @@
-import datetime
 import json
 import os
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
-
 HERE = Path(os.path.dirname(__file__))
-
-
-DOSSIERS = HERE / "sample_data" / "Dossiers_Legislatifs_XV.json"
-
-
-@pytest.fixture(scope="module")
-def textes():
-    from zam_repondeur.fetch.an.dossiers.dossiers_legislatifs import parse_textes
-
-    with open(DOSSIERS) as f_:
-        data = json.load(f_)
-    return parse_textes(data["export"])
-
-
-@pytest.fixture(scope="module")
-def dossiers():
-    from zam_repondeur.fetch.an.dossiers.dossiers_legislatifs import (
-        get_dossiers_legislatifs
-    )
-
-    with patch(
-        "zam_repondeur.fetch.an.dossiers.dossiers_legislatifs.extract_from_remote_zip"
-    ) as m_open:
-        m_open.return_value = DOSSIERS.open()
-        dossiers_by_uid = get_dossiers_legislatifs(15)
-
-    return dossiers_by_uid
 
 
 def test_number_of_dossiers(dossiers):
@@ -48,173 +18,97 @@ def dossier_plfss_2018():
 
 
 def test_parse_dossier_plfss_2018(dossier_plfss_2018, textes):
+    from zam_repondeur.models import Lecture, Texte
     from zam_repondeur.fetch.an.dossiers.dossiers_legislatifs import parse_dossier
-    from zam_repondeur.fetch.an.dossiers.models import (
-        Chambre,
-        Lecture,
-        Texte,
-        TypeTexte,
-    )
+    from zam_repondeur.fetch.an.dossiers.models import Chambre
 
     dossier = parse_dossier(dossier_plfss_2018, textes)
 
     assert dossier.uid == "DLR5L15N36030"
     assert dossier.titre == "Sécurité sociale : loi de financement 2018"
     assert dossier.lectures == [
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie au fond",
-            texte=Texte(
-                uid="PRJLANR5L15B0269",
-                type_=TypeTexte.PROJET,
-                numero=269,
-                titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
-                titre_court="PLFSS pour 2018",
-                date_depot=datetime.date(2017, 10, 11),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0269"),
+            partie=None,
             organe="PO420120",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie pour avis",
-            texte=Texte(
-                uid="PRJLANR5L15B0269",
-                type_=TypeTexte.PROJET,
-                numero=269,
-                titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
-                titre_court="PLFSS pour 2018",
-                date_depot=datetime.date(2017, 10, 11),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0269"),
+            partie=None,
             organe="PO59048",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Séance publique",
-            texte=Texte(
-                uid="PRJLANR5L15B0269",
-                type_=TypeTexte.PROJET,
-                numero=269,
-                titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
-                titre_court="PLFSS pour 2018",
-                date_depot=datetime.date(2017, 10, 11),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0269"),
+            partie=None,
             organe="PO717460",
         ),
-        Lecture(
-            chambre=Chambre.SENAT,
-            titre="Première lecture – Commission saisie au fond",
-            texte=Texte(
-                uid="PRJLSNR5S299B0063",
-                type_=TypeTexte.PROJET,
-                numero=63,
-                titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
-                titre_court="PLFSS pour 2018",
-                date_depot=datetime.date(2017, 11, 6),
-            ),
+        Lecture.get(
+            session="2017-2018",
+            chambre=str(Chambre.SENAT),
+            texte=Texte.get(uid="PRJLSNR5S299B0063"),
+            partie=None,
             organe="PO211493",
         ),
-        Lecture(
-            chambre=Chambre.SENAT,
-            titre="Première lecture – Commission saisie pour avis",
-            texte=Texte(
-                uid="PRJLSNR5S299B0063",
-                type_=TypeTexte.PROJET,
-                numero=63,
-                titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
-                titre_court="PLFSS pour 2018",
-                date_depot=datetime.date(2017, 11, 6),
-            ),
+        Lecture.get(
+            session="2017-2018",
+            chambre=str(Chambre.SENAT),
+            texte=Texte.get(uid="PRJLSNR5S299B0063"),
+            partie=None,
             organe="PO211494",
         ),
-        Lecture(
-            chambre=Chambre.SENAT,
-            titre="Première lecture – Séance publique",
-            texte=Texte(
-                uid="PRJLSNR5S299B0063",
-                type_=TypeTexte.PROJET,
-                numero=63,
-                titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
-                titre_court="PLFSS pour 2018",
-                date_depot=datetime.date(2017, 11, 6),
-            ),
+        Lecture.get(
+            session="2017-2018",
+            chambre=str(Chambre.SENAT),
+            texte=Texte.get(uid="PRJLSNR5S299B0063"),
+            partie=None,
             organe="PO78718",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Nouvelle lecture – Commission saisie au fond",
-            texte=Texte(
-                uid="PRJLANR5L15B0387",
-                type_=TypeTexte.PROJET,
-                numero=387,
-                titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
-                titre_court="PLFSS pour 2018",
-                date_depot=datetime.date(2017, 11, 21),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0387"),
+            partie=None,
             organe="PO420120",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Nouvelle lecture – Séance publique",
-            texte=Texte(
-                uid="PRJLANR5L15B0387",
-                type_=TypeTexte.PROJET,
-                numero=387,
-                titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
-                titre_court="PLFSS pour 2018",
-                date_depot=datetime.date(2017, 11, 21),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0387"),
+            partie=None,
             organe="PO717460",
         ),
-        Lecture(
-            chambre=Chambre.SENAT,
-            titre="Nouvelle lecture – Commission saisie au fond",
-            texte=Texte(
-                uid="PRJLSNR5S299B0121",
-                type_=TypeTexte.PROJET,
-                numero=121,
-                titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
-                titre_court="PLFSS pour 2018",
-                date_depot=datetime.date(2017, 11, 30),
-            ),
+        Lecture.get(
+            session="2017-2018",
+            chambre=str(Chambre.SENAT),
+            texte=Texte.get(uid="PRJLSNR5S299B0121"),
+            partie=None,
             organe="PO211493",
         ),
-        Lecture(
-            chambre=Chambre.SENAT,
-            titre="Nouvelle lecture – Séance publique",
-            texte=Texte(
-                uid="PRJLSNR5S299B0121",
-                type_=TypeTexte.PROJET,
-                numero=121,
-                titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
-                titre_court="PLFSS pour 2018",
-                date_depot=datetime.date(2017, 11, 30),
-            ),
+        Lecture.get(
+            session="2017-2018",
+            chambre=str(Chambre.SENAT),
+            texte=Texte.get(uid="PRJLSNR5S299B0121"),
+            partie=None,
             organe="PO78718",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Lecture définitive – Commission saisie au fond",
-            texte=Texte(
-                uid="PRJLANR5L15B0434",
-                type_=TypeTexte.PROJET,
-                numero=434,
-                titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
-                titre_court="PLFSS pour 2018",
-                date_depot=datetime.date(2017, 12, 1),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0434"),
+            partie=None,
             organe="PO420120",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Lecture définitive – Séance publique",
-            texte=Texte(
-                uid="PRJLANR5L15B0434",
-                type_=TypeTexte.PROJET,
-                numero=434,
-                titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
-                titre_court="PLFSS pour 2018",
-                date_depot=datetime.date(2017, 12, 1),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0434"),
+            partie=None,
             organe="PO717460",
         ),
     ]
@@ -227,522 +121,288 @@ def dossier_plf_2018():
 
 
 def test_parse_dossier_plf_2018(dossier_plf_2018, textes):
+    from zam_repondeur.models import Lecture, Texte
     from zam_repondeur.fetch.an.dossiers.dossiers_legislatifs import parse_dossier
-    from zam_repondeur.fetch.an.dossiers.models import (
-        Chambre,
-        Lecture,
-        Texte,
-        TypeTexte,
-    )
+    from zam_repondeur.fetch.an.dossiers.models import Chambre
 
     dossier = parse_dossier(dossier_plf_2018, textes)
 
     assert dossier.uid == "DLR5L15N35854"
     assert dossier.titre == "Budget : loi de finances 2018"
     assert dossier.lectures == [
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie au fond",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=1,
             organe="PO59048",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie au fond",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=2,
             organe="PO59048",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie pour avis",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=1,
             organe="PO420120",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie pour avis",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=2,
             organe="PO420120",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie pour avis",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=1,
             organe="PO419604",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie pour avis",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=2,
             organe="PO419604",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie pour avis",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=1,
             organe="PO419610",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie pour avis",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=2,
             organe="PO419610",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie pour avis",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=1,
             organe="PO59047",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie pour avis",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=2,
             organe="PO59047",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie pour avis",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=1,
             organe="PO59046",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie pour avis",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=2,
             organe="PO59046",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie pour avis",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=1,
             organe="PO59051",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie pour avis",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=2,
             organe="PO59051",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie pour avis",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=1,
             organe="PO419865",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Commission saisie pour avis",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=2,
             organe="PO419865",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Séance publique",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=1,
             organe="PO717460",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Première lecture – Séance publique",
-            texte=Texte(
-                uid="PRJLANR5L15B0235",
-                type_=TypeTexte.PROJET,
-                numero=235,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 9, 27),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0235"),
             partie=2,
             organe="PO717460",
         ),
-        Lecture(
-            chambre=Chambre.SENAT,
-            titre="Première lecture – Commission saisie au fond",
-            texte=Texte(
-                uid="PRJLSNR5S299B0107",
-                type_=TypeTexte.PROJET,
-                numero=107,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 11, 23),
-            ),
+        Lecture.get(
+            session="2018-2019",
+            chambre=str(Chambre.SENAT),
+            texte=Texte.get(uid="PRJLSNR5S299B0107"),
             partie=1,
             organe="PO211494",
         ),
-        Lecture(
-            chambre=Chambre.SENAT,
-            titre="Première lecture – Commission saisie au fond",
-            texte=Texte(
-                uid="PRJLSNR5S299B0107",
-                type_=TypeTexte.PROJET,
-                numero=107,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 11, 23),
-            ),
+        Lecture.get(
+            session="2018-2019",
+            chambre=str(Chambre.SENAT),
+            texte=Texte.get(uid="PRJLSNR5S299B0107"),
             partie=2,
             organe="PO211494",
         ),
-        Lecture(
-            chambre=Chambre.SENAT,
-            titre="Première lecture – Séance publique",
-            texte=Texte(
-                uid="PRJLSNR5S299B0107",
-                type_=TypeTexte.PROJET,
-                numero=107,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 11, 23),
-            ),
+        Lecture.get(
+            session="2018-2019",
+            chambre=str(Chambre.SENAT),
+            texte=Texte.get(uid="PRJLSNR5S299B0107"),
             partie=1,
             organe="PO78718",
         ),
-        Lecture(
-            chambre=Chambre.SENAT,
-            titre="Première lecture – Séance publique",
-            texte=Texte(
-                uid="PRJLSNR5S299B0107",
-                type_=TypeTexte.PROJET,
-                numero=107,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 11, 23),
-            ),
+        Lecture.get(
+            session="2018-2019",
+            chambre=str(Chambre.SENAT),
+            texte=Texte.get(uid="PRJLSNR5S299B0107"),
             partie=2,
             organe="PO78718",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Nouvelle lecture – Commission saisie au fond",
-            texte=Texte(
-                uid="PRJLANR5L15B0485",
-                type_=TypeTexte.PROJET,
-                numero=485,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 12, 12),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0485"),
+            partie=None,
             organe="PO59048",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Nouvelle lecture – Séance publique",
-            texte=Texte(
-                uid="PRJLANR5L15B0485",
-                type_=TypeTexte.PROJET,
-                numero=485,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 12, 12),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0485"),
+            partie=None,
             organe="PO717460",
         ),
-        Lecture(
-            chambre=Chambre.SENAT,
-            titre="Nouvelle lecture – Commission saisie au fond",
-            texte=Texte(
-                uid="PRJLSNR5S299B0172",
-                type_=TypeTexte.PROJET,
-                numero=172,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 12, 18),
-            ),
+        Lecture.get(
+            session="2018-2019",
+            chambre=str(Chambre.SENAT),
+            texte=Texte.get(uid="PRJLSNR5S299B0172"),
+            partie=None,
             organe="PO211494",
         ),
-        Lecture(
-            chambre=Chambre.SENAT,
-            titre="Nouvelle lecture – Séance publique",
-            texte=Texte(
-                uid="PRJLSNR5S299B0172",
-                type_=TypeTexte.PROJET,
-                numero=172,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 12, 18),
-            ),
+        Lecture.get(
+            session="2018-2019",
+            chambre=str(Chambre.SENAT),
+            texte=Texte.get(uid="PRJLSNR5S299B0172"),
+            partie=None,
             organe="PO78718",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Lecture définitive – Commission saisie au fond",
-            texte=Texte(
-                uid="PRJLANR5L15B0506",
-                type_=TypeTexte.PROJET,
-                numero=506,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 12, 19),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0506"),
+            partie=None,
             organe="PO59048",
         ),
-        Lecture(
-            chambre=Chambre.AN,
-            titre="Lecture définitive – Séance publique",
-            texte=Texte(
-                uid="PRJLANR5L15B0506",
-                type_=TypeTexte.PROJET,
-                numero=506,
-                titre_long="projet de loi de finances pour 2018",
-                titre_court="PLF pour 2018",
-                date_depot=datetime.date(2017, 12, 19),
-            ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0506"),
+            partie=None,
             organe="PO717460",
         ),
     ]
 
 
 @pytest.fixture
-def dossier_essoc():
+def dossier_essoc_dict():
     with open(HERE / "sample_data" / "dossier-DLR5L15N36159.json") as f_:
         return json.load(f_)["dossierParlementaire"]
 
 
-def test_parse_dossier_essoc(dossier_essoc, textes):
+def test_parse_dossier_essoc(dossier_essoc_dict, textes):
+    from zam_repondeur.models import Lecture, Texte
     from zam_repondeur.fetch.an.dossiers.dossiers_legislatifs import parse_dossier
-    from zam_repondeur.fetch.an.dossiers.models import (
-        Chambre,
-        Lecture,
-        Dossier,
-        Texte,
-        TypeTexte,
-    )
+    from zam_repondeur.fetch.an.dossiers.models import Chambre
 
-    dossier = parse_dossier(dossier_essoc, textes)
+    dossier = parse_dossier(dossier_essoc_dict, textes)
 
-    assert dossier == Dossier(
-        uid="DLR5L15N36159",
-        titre="Fonction publique : un Etat au service d'une société de confiance",
-        lectures=[
-            Lecture(
-                chambre=Chambre.AN,
-                titre="Première lecture – Commission saisie au fond",
-                texte=Texte(
-                    uid="PRJLANR5L15B0424",
-                    type_=TypeTexte.PROJET,
-                    numero=424,
-                    titre_long="projet de loi pour un Etat au service d’une société de confiance",  # noqa
-                    titre_court="Etat service société de confiance",
-                    date_depot=datetime.date(2017, 11, 27),
-                ),
-                organe="PO744107",
-            ),
-            Lecture(
-                chambre=Chambre.AN,
-                titre="Première lecture – Séance publique",
-                texte=Texte(
-                    uid="PRJLANR5L15BTC0575",
-                    type_=TypeTexte.PROJET,
-                    numero=575,
-                    titre_long="projet de loi sur le projet de loi, après engagement de la procédure accélérée, pour un Etat au service d’une société de confiance (n°424).",  # noqa
-                    titre_court="Etat service société de confiance",
-                    date_depot=datetime.date(2018, 1, 18),
-                ),
-                organe="PO717460",
-            ),
-            Lecture(
-                chambre=Chambre.SENAT,
-                titre="Première lecture – Commission saisie au fond",
-                texte=Texte(
-                    uid="PRJLSNR5S299B0259",
-                    type_=TypeTexte.PROJET,
-                    numero=259,
-                    titre_long="projet de loi pour un Etat au service d'une société de confiance",  # noqa
-                    titre_court="État au service d'une société de confiance",
-                    date_depot=datetime.date(2018, 1, 31),
-                ),
-                organe="PO748821",
-            ),
-            Lecture(
-                chambre=Chambre.SENAT,
-                titre="Première lecture – Séance publique",
-                texte=Texte(
-                    uid="PRJLSNR5S299BTC0330",
-                    type_=TypeTexte.PROJET,
-                    numero=330,
-                    titre_long="projet de loi  sur le projet de loi, adopté, par l'Assemblée nationale après engagement de la procédure accélérée, pour un Etat au service d'une société de confiance (n°259).",  # noqa
-                    titre_court="État au service d'une société de confiance",
-                    date_depot=datetime.date(2018, 2, 22),
-                ),
-                organe="PO78718",
-            ),
-            Lecture(
-                chambre=Chambre.AN,
-                titre="Nouvelle lecture – Commission saisie au fond",
-                texte=Texte(
-                    uid="PRJLANR5L15B0806",
-                    type_=TypeTexte.PROJET,
-                    numero=806,
-                    titre_long="projet de loi renforçant l'efficacité de l'administration pour une relation de confiance avec le public",  # noqa
-                    titre_court="Renforcement de l'efficacité de l'administration pour une relation de confiance avec le public",  # noqa
-                    date_depot=datetime.date(2018, 3, 21),
-                ),
-                organe="PO744107",
-            ),
-            Lecture(
-                chambre=Chambre.AN,
-                titre="Nouvelle lecture – Séance publique",
-                texte=Texte(
-                    uid="PRJLANR5L15BTC1056",
-                    type_=TypeTexte.PROJET,
-                    numero=1056,
-                    titre_long="projet de loi , en nouvelle lecture, sur le projet de loi, modifié par le Sénat, renforçant l'efficacité de l'administration pour une relation de confiance avec le public (n°806).",  # noqa
-                    titre_court="Renforcement de l'efficacité de l'administration pour une relation de confiance avec le public",  # noqa
-                    date_depot=datetime.date(2018, 6, 13),
-                ),
-                organe="PO717460",
-            ),
-        ],
+    assert dossier.uid == "DLR5L15N36159"
+    assert (
+        dossier.titre
+        == "Fonction publique : un Etat au service d'une société de confiance"
     )
+    assert dossier.lectures == [
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0424"),
+            partie=None,
+            organe="PO744107",
+        ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15BTC0575"),
+            partie=None,
+            organe="PO717460",
+        ),
+        Lecture.get(
+            session="2018-2019",
+            chambre=str(Chambre.SENAT),
+            texte=Texte.get(uid="PRJLSNR5S299B0259"),
+            partie=None,
+            organe="PO748821",
+        ),
+        Lecture.get(
+            session="2018-2019",
+            chambre=str(Chambre.SENAT),
+            texte=Texte.get(uid="PRJLSNR5S299BTC0330"),
+            partie=None,
+            organe="PO78718",
+        ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15B0806"),
+            partie=None,
+            organe="PO744107",
+        ),
+        Lecture.get(
+            session="15",
+            chambre=str(Chambre.AN),
+            texte=Texte.get(uid="PRJLANR5L15BTC1056"),
+            partie=None,
+            organe="PO717460",
+        ),
+    ]
 
 
 @pytest.fixture
-def dossier_pacte_ferroviaire():
+def dossier_pacte_ferroviaire_dict():
     with open(HERE / "sample_data" / "dossier-DLR5L15N36460.json") as f_:
         return json.load(f_)["dossierParlementaire"]
 
 
-def test_dossier_pacte_ferroviaire(dossier_pacte_ferroviaire, textes):
+def test_dossier_pacte_ferroviaire(dossier_pacte_ferroviaire_dict, textes):
     from zam_repondeur.fetch.an.dossiers.dossiers_legislatifs import parse_dossier
 
-    dossier = parse_dossier(dossier_pacte_ferroviaire, textes)
+    dossier = parse_dossier(dossier_pacte_ferroviaire_dict, textes)
 
     assert dossier.uid == "DLR5L15N36460"
     assert len(dossier.lectures) > 4
@@ -755,23 +415,39 @@ def test_extract_actes(dossier_essoc):
 
 
 class TestGenLectures:
-    def test_gen_lectures_essoc(self, dossier_essoc, textes):
-        from zam_repondeur.fetch.an.dossiers.dossiers_legislatifs import gen_lectures
+    def test_create_lectures_essoc(self, dossier_essoc_dict, textes):
+        from zam_repondeur.models import DBSession, Lecture
+        from zam_repondeur.fetch.an.dossiers.dossiers_legislatifs import (
+            create_lectures,
+            parse_dossier,
+        )
 
-        acte = dossier_essoc["actesLegislatifs"]["acteLegislatif"][0]
+        acte = dossier_essoc_dict["actesLegislatifs"]["acteLegislatif"][0]
 
-        lectures = list(gen_lectures(acte, textes))
+        dossier = parse_dossier(dossier_essoc_dict, textes)
+        create_lectures(dossier, acte, textes)
+
+        lectures = DBSession.query(Lecture).all()
 
         assert len(lectures) == 2
         assert "Commission saisie au fond" in lectures[0].titre
         assert "Séance publique" in lectures[1].titre
 
-    def test_gen_lectures_pacte_ferroviaire(self, dossier_pacte_ferroviaire, textes):
-        from zam_repondeur.fetch.an.dossiers.dossiers_legislatifs import gen_lectures
+    def test_create_lectures_pacte_ferroviaire(
+        self, dossier_pacte_ferroviaire_dict, textes
+    ):
+        from zam_repondeur.models import DBSession, Lecture
+        from zam_repondeur.fetch.an.dossiers.dossiers_legislatifs import (
+            create_lectures,
+            parse_dossier,
+        )
 
-        acte = dossier_pacte_ferroviaire["actesLegislatifs"]["acteLegislatif"][0]
+        acte = dossier_pacte_ferroviaire_dict["actesLegislatifs"]["acteLegislatif"][0]
 
-        lectures = list(gen_lectures(acte, textes))
+        dossier = parse_dossier(dossier_pacte_ferroviaire_dict, textes)
+        create_lectures(dossier, acte, textes)
+
+        lectures = DBSession.query(Lecture).all()
 
         assert len(lectures) == 3
         assert "Commission saisie au fond" in lectures[0].titre
@@ -779,13 +455,13 @@ class TestGenLectures:
         assert "Séance publique" in lectures[2].titre
 
 
-def test_walk_actes(dossier_essoc, textes):
+def test_walk_actes(dossier_essoc_dict, textes):
     from zam_repondeur.fetch.an.dossiers.dossiers_legislatifs import (
         walk_actes,
         WalkResult,
     )
 
-    acte = dossier_essoc["actesLegislatifs"]["acteLegislatif"][0]
+    acte = dossier_essoc_dict["actesLegislatifs"]["acteLegislatif"][0]
     assert list(walk_actes(acte)) == [
         WalkResult(
             phase="COM-FOND",

--- a/repondeur/tests/fetch/test_update_liasse_xml.py
+++ b/repondeur/tests/fetch/test_update_liasse_xml.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 
-# We need data about dossiers, texts and groups
+# We need data about groups
 pytestmark = pytest.mark.usefixtures("data_repository")
 
 
@@ -14,7 +14,7 @@ def open_liasse(filename):
     return (Path(__file__).parent.parent / "sample_data" / filename).open(mode="rb")
 
 
-def test_article_changed(lecture_essoc):
+def test_article_changed(textes, dossiers, lecture_essoc):
     from zam_repondeur.fetch.an.liasse_xml import import_liasse_xml
 
     # Let's import amendements
@@ -29,7 +29,7 @@ def test_article_changed(lecture_essoc):
     assert errors == []
 
 
-def test_add_parent_amendement(lecture_essoc):
+def test_add_parent_amendement(textes, dossiers, lecture_essoc):
     from zam_repondeur.fetch.an.liasse_xml import import_liasse_xml
 
     # Let's import amendements without a parent
@@ -44,7 +44,7 @@ def test_add_parent_amendement(lecture_essoc):
     assert errors == []
 
 
-def test_remove_parent_amendement(lecture_essoc):
+def test_remove_parent_amendement(textes, dossiers, lecture_essoc):
     from zam_repondeur.fetch.an.liasse_xml import import_liasse_xml
 
     # Let's import amendements with a parent

--- a/repondeur/tests/fixtures/dossiers.py
+++ b/repondeur/tests/fixtures/dossiers.py
@@ -4,74 +4,81 @@ from unittest.mock import patch
 import pytest
 
 
-@pytest.yield_fixture(scope="session", autouse=True)
-def mock_dossiers():
-    from zam_repondeur.fetch.an.dossiers.models import (
-        Chambre,
-        Dossier,
-        Lecture,
-        Texte,
-        TypeTexte,
-    )
+@pytest.yield_fixture(autouse=True)
+def mock_dossiers(db):
+    from zam_repondeur.models import Dossier, Texte, Lecture
+    from zam_repondeur.fetch.an.dossiers.models import Chambre, TypeTexte
 
-    with patch("zam_repondeur.data.get_dossiers_legislatifs") as m_dossiers:
+    with patch(
+        "zam_repondeur.fetch.an.dossiers.dossiers_legislatifs.get_dossiers_legislatifs"
+    ) as m_dossiers:
+        dossier_DLR5L15N36030 = Dossier.create(
+            uid="DLR5L15N36030", titre="Sécurité sociale : loi de financement 2018"
+        )
+        dossier_DLR5L15N36030.lectures.append(
+            Lecture.create(
+                chambre=str(Chambre.AN),
+                session="15",
+                titre="Première lecture – Titre lecture",
+                texte=Texte.create(
+                    uid="PRJLANR5L15B0269",
+                    type_=str(TypeTexte.PROJET),
+                    numero=269,
+                    titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
+                    titre_court="PLFSS pour 2018",
+                    date_depot=date(2017, 10, 11),
+                    lectures=[],
+                ),
+                dossier=dossier_DLR5L15N36030,
+                organe="PO717460",  # séance publique
+            )
+        )
+        dossier_DLR5L15N36159 = Dossier.create(
+            uid="DLR5L15N36159",
+            titre="Fonction publique : un Etat au service d'une société de confiance",
+        )
+        dossier_DLR5L15N36159.lectures.append(
+            Lecture.create(
+                chambre=str(Chambre.AN),
+                session="15",
+                titre="Nouvelle lecture – Titre lecture",
+                texte=Texte.create(
+                    uid="PRJLANR5L15B0806",
+                    type_=str(TypeTexte.PROJET),
+                    numero=806,
+                    titre_long="projet de loi renforçant l'efficacité de l'administration pour une relation de confiance avec le public",  # noqa
+                    titre_court="Renforcement de l'efficacité de l'administration pour une relation de confiance avec le public",  # noqa
+                    date_depot=date(2018, 3, 21),
+                    lectures=[],
+                ),
+                dossier=dossier_DLR5L15N36159,
+                organe="PO744107",  # commission spéciale
+            )
+        )
+        dossier_DLR5L15N36892 = Dossier(
+            uid="DLR5L15N36892", titre="Sécurité sociale : loi de financement 2019"
+        )
+        dossier_DLR5L15N36892.lectures.append(
+            Lecture.create(
+                chambre=str(Chambre.SENAT),
+                session="2018-2019",
+                titre="Première lecture – Titre lecture",
+                texte=Texte.create(
+                    uid="PRJLSNR5S319B0106",
+                    type_=str(TypeTexte.PROJET),
+                    numero=106,
+                    titre_long="projet de loi de financement de la sécurité sociale pour 2019",  # noqa
+                    titre_court="PLFSS pour 2019",
+                    date_depot=date(2018, 11, 5),
+                    lectures=[],
+                ),
+                dossier=dossier_DLR5L15N36892,
+                organe="PO78718",  # séance publique
+            )
+        )
         m_dossiers.return_value = {
-            "DLR5L15N36030": Dossier(
-                uid="DLR5L15N36030",
-                titre="Sécurité sociale : loi de financement 2018",
-                lectures=[
-                    Lecture(
-                        chambre=Chambre.AN,
-                        titre="Première lecture – Titre lecture",
-                        texte=Texte(
-                            uid="PRJLANR5L15B0269",
-                            type_=TypeTexte.PROJET,
-                            numero=269,
-                            titre_long="projet de loi de financement de la sécurité sociale pour 2018",  # noqa
-                            titre_court="PLFSS pour 2018",
-                            date_depot=date(2017, 10, 11),
-                        ),
-                        organe="PO717460",  # séance publique
-                    )
-                ],
-            ),
-            "DLR5L15N36159": Dossier(
-                uid="DLR5L15N36159",
-                titre="Fonction publique : un Etat au service d'une société de confiance",  # noqa
-                lectures=[
-                    Lecture(
-                        chambre=Chambre.AN,
-                        titre="Nouvelle lecture – Titre lecture",
-                        texte=Texte(
-                            uid="PRJLANR5L15B0806",
-                            type_=TypeTexte.PROJET,
-                            numero=806,
-                            titre_long="projet de loi renforçant l'efficacité de l'administration pour une relation de confiance avec le public",  # noqa
-                            titre_court="Renforcement de l'efficacité de l'administration pour une relation de confiance avec le public",  # noqa
-                            date_depot=date(2018, 3, 21),
-                        ),
-                        organe="PO744107",  # commission spéciale
-                    )
-                ],
-            ),
-            "DLR5L15N36892": Dossier(
-                uid="DLR5L15N36892",
-                titre="Sécurité sociale : loi de financement 2019",
-                lectures=[
-                    Lecture(
-                        chambre=Chambre.SENAT,
-                        titre="Première lecture – Titre lecture",
-                        texte=Texte(
-                            uid="PRJLSNR5S319B0106",
-                            type_=TypeTexte.PROJET,
-                            numero=106,
-                            titre_long="projet de loi de financement de la sécurité sociale pour 2019",  # noqa
-                            titre_court="PLFSS pour 2019",
-                            date_depot=date(2018, 11, 5),
-                        ),
-                        organe="PO78718",  # séance publique
-                    )
-                ],
-            ),
+            "DLR5L15N36030": dossier_DLR5L15N36030,
+            "DLR5L15N36159": dossier_DLR5L15N36159,
+            "DLR5L15N36892": dossier_DLR5L15N36892,
         }
         yield

--- a/repondeur/tests/models/test_base.py
+++ b/repondeur/tests/models/test_base.py
@@ -12,7 +12,7 @@ class TestRepr:
 
     def test_lecture(self, lecture_an):
         expected_repr = (
-            "<Lecture pk=1 chambre='an' session='15' organe='PO717460' num_texte=269 "
+            "<Lecture pk=1 chambre='an' session='15' organe='PO717460' "
             "partie=None owned_by_team=None>"
         )
         assert repr(lecture_an) == expected_repr

--- a/repondeur/tests/models/test_lecture.py
+++ b/repondeur/tests/models/test_lecture.py
@@ -6,13 +6,13 @@ pytestmark = pytest.mark.usefixtures("data_repository")
 
 
 class TestLectureToStr:
-    def test_an_seance_publique(self):
+    def test_an_seance_publique(self, texte_an):
         from zam_repondeur.models import Lecture
 
         lecture = Lecture(
             chambre="an",
             session="15",
-            num_texte=269,
+            texte=texte_an,
             titre="Nouvelle lecture – Titre lecture",
             organe="PO717460",
         )
@@ -22,13 +22,13 @@ class TestLectureToStr:
         )
         assert str(lecture) == result
 
-    def test_an_commission(self):
+    def test_an_commission(self, texte_an):
         from zam_repondeur.models import Lecture
 
         lecture = Lecture(
             chambre="an",
             session="15",
-            num_texte=269,
+            texte=texte_an,
             titre="Nouvelle lecture – Titre lecture",
             organe="PO59048",
         )
@@ -38,13 +38,13 @@ class TestLectureToStr:
         )
         assert str(lecture) == result
 
-    def test_an_commission_speciale(self):
+    def test_an_commission_speciale(self, texte_commission_publique):
         from zam_repondeur.models import Lecture
 
         lecture = Lecture(
             chambre="an",
             session="15",
-            num_texte=806,
+            texte=texte_commission_publique,
             titre="Nouvelle lecture – Titre lecture",
             organe="PO744107",
         )
@@ -54,13 +54,13 @@ class TestLectureToStr:
         )
         assert str(lecture) == result
 
-    def test_senat_seance_publique(self):
+    def test_senat_seance_publique(self, texte_senat):
         from zam_repondeur.models import Lecture
 
         lecture = Lecture(
             chambre="senat",
             session="2017-2018",
-            num_texte=63,
+            texte=texte_senat,
             titre="Nouvelle lecture – Titre lecture",
             organe="PO78718",
         )

--- a/repondeur/tests/test_amendement_edit.py
+++ b/repondeur/tests/test_amendement_edit.py
@@ -424,7 +424,7 @@ def test_post_amendement_edit_form_updates_modification_dates_only_if_modified(
     lecture = Lecture.get(
         chambre=lecture_an.chambre,
         session=lecture_an.session,
-        num_texte=lecture_an.num_texte,
+        texte=lecture_an.texte,
         partie=None,
         organe=lecture_an.organe,
     )

--- a/repondeur/tests/test_data.py
+++ b/repondeur/tests/test_data.py
@@ -1,11 +1,3 @@
-def test_get_dossiers(app):
-    from zam_repondeur.data import repository
-
-    dossiers = repository.get_data("dossiers")
-
-    assert "DLR5L15N36030" in dossiers
-
-
 def test_get_organes(app):
     from zam_repondeur.data import repository
 

--- a/repondeur/tests/test_fetch_articles.py
+++ b/repondeur/tests/test_fetch_articles.py
@@ -6,35 +6,19 @@ import transaction
 
 
 class TestGetPossibleUrls:
-    def test_assemblee_nationale(self):
+    def test_assemblee_nationale(self, lecture_an):
         from zam_repondeur.fetch.articles import get_possible_texte_urls
-        from zam_repondeur.models import Lecture
 
-        lecture = Lecture(
-            chambre="an",
-            session="15",
-            num_texte=269,
-            titre="Titre lecture",
-            organe="PO420120",
-        )
-        assert get_possible_texte_urls(lecture) == [
+        assert get_possible_texte_urls(lecture_an) == [
             "http://www.assemblee-nationale.fr/15/projets/pl0269.asp",
             "http://www.assemblee-nationale.fr/15/propositions/pion0269.asp",
             "http://www.assemblee-nationale.fr/15/ta-commission/r0269-a0.asp",
         ]
 
-    def test_senat(self):
+    def test_senat(self, lecture_senat):
         from zam_repondeur.fetch.articles import get_possible_texte_urls
-        from zam_repondeur.models import Lecture
 
-        lecture = Lecture(
-            chambre="senat",
-            session="2017-2018",
-            num_texte=63,
-            titre="Titre lecture",
-            organe="PO78718",
-        )
-        assert get_possible_texte_urls(lecture) == [
+        assert get_possible_texte_urls(lecture_senat) == [
             "https://www.senat.fr/leg/pjl17-063.html"
         ]
 
@@ -159,7 +143,7 @@ class TestGetArticlesAN:
         from zam_repondeur.fetch.articles import get_articles
         from zam_repondeur.models import DBSession, Article
 
-        lecture_an.num_texte = 1056
+        lecture_an.texte.numero = 1056
         lecture_an.organe = "PO717460"
         lecture_an.titre = "Première lecture – Séance publique"
         DBSession.add(lecture_an)
@@ -269,7 +253,7 @@ class TestGetArticlesAN:
         from zam_repondeur.models import DBSession, Amendement
 
         with transaction.manager:
-            lecture_an.num_texte = 575
+            lecture_an.texte.numero = 575
             lecture_an.organe = "PO717460"
             lecture_an.titre = "Première lecture – Séance publique"
 

--- a/repondeur/tests/test_generate_pdf.py
+++ b/repondeur/tests/test_generate_pdf.py
@@ -184,9 +184,7 @@ def test_generate_pdf_with_amendement_content(
     amendement_6666.user_content.reponse = "La réponse"
     DBSession.add(amendement_6666)
     lecture_senat = (
-        DBSession.query(Lecture)
-        .filter(Lecture.num_texte == lecture_senat.num_texte)
-        .first()
+        DBSession.query(Lecture).filter(Lecture.texte == lecture_senat.texte).first()
     )
     parser = HTMLParser(
         generate_html_for_pdf(DummyRequest(), "print.html", {"lecture": lecture_senat})
@@ -237,9 +235,7 @@ def test_generate_pdf_with_amendement_content_factor_authors_groups(
     amendement_9999.user_content.reponse = "La réponse"
     DBSession.add(amendement_9999)
     lecture_senat = (
-        DBSession.query(Lecture)
-        .filter(Lecture.num_texte == lecture_senat.num_texte)
-        .first()
+        DBSession.query(Lecture).filter(Lecture.texte == lecture_senat.texte).first()
     )
     parser = HTMLParser(
         generate_html_for_pdf(DummyRequest(), "print.html", {"lecture": lecture_senat})
@@ -291,9 +287,7 @@ def test_generate_pdf_with_amendement_content_factor_only_groups(
     amendement_9999.user_content.reponse = "La réponse"
     DBSession.add(amendement_9999)
     lecture_senat = (
-        DBSession.query(Lecture)
-        .filter(Lecture.num_texte == lecture_senat.num_texte)
-        .first()
+        DBSession.query(Lecture).filter(Lecture.texte == lecture_senat.texte).first()
     )
     parser = HTMLParser(
         generate_html_for_pdf(DummyRequest(), "print.html", {"lecture": lecture_senat})
@@ -389,9 +383,7 @@ def test_generate_pdf_with_amendement_content_factor_many_authors_groups(
         reponse="La réponse",
     )
     lecture_senat = (
-        DBSession.query(Lecture)
-        .filter(Lecture.num_texte == lecture_senat.num_texte)
-        .first()
+        DBSession.query(Lecture).filter(Lecture.texte == lecture_senat.texte).first()
     )
     parser = HTMLParser(
         generate_html_for_pdf(DummyRequest(), "print.html", {"lecture": lecture_senat})
@@ -437,9 +429,7 @@ def test_generate_pdf_with_amendement_content_gouvernemental(
     amendement_6666.user_content.reponse = "La présentation"
     DBSession.add(amendement_6666)
     lecture_senat = (
-        DBSession.query(Lecture)
-        .filter(Lecture.num_texte == lecture_senat.num_texte)
-        .first()
+        DBSession.query(Lecture).filter(Lecture.texte == lecture_senat.texte).first()
     )
     parser = HTMLParser(
         generate_html_for_pdf(DummyRequest(), "print.html", {"lecture": lecture_senat})

--- a/repondeur/tests/test_lecture_delete.py
+++ b/repondeur/tests/test_lecture_delete.py
@@ -4,7 +4,7 @@ def test_lecture_delete(app, lecture_an, amendements_an, user_david_table_an):
     assert Lecture.exists(
         chambre=lecture_an.chambre,
         session=lecture_an.session,
-        num_texte=lecture_an.num_texte,
+        texte=lecture_an.texte,
         partie=None,
         organe=lecture_an.organe,
     )
@@ -31,7 +31,7 @@ def test_lecture_delete(app, lecture_an, amendements_an, user_david_table_an):
     assert not Lecture.exists(
         chambre=lecture_an.chambre,
         session=lecture_an.session,
-        num_texte=lecture_an.num_texte,
+        texte=lecture_an.texte,
         partie=None,
         organe=lecture_an.organe,
     )
@@ -46,7 +46,7 @@ def test_lecture_delete_alien_user(
     assert Lecture.exists(
         chambre=lecture_an.chambre,
         session=lecture_an.session,
-        num_texte=lecture_an.num_texte,
+        texte=lecture_an.texte,
         partie=None,
         organe=lecture_an.organe,
     )
@@ -69,7 +69,7 @@ def test_lecture_delete_alien_user(
     assert Lecture.exists(
         chambre=lecture_an.chambre,
         session=lecture_an.session,
-        num_texte=lecture_an.num_texte,
+        texte=lecture_an.texte,
         partie=None,
         organe=lecture_an.organe,
     )

--- a/repondeur/tests/test_lectures_add.py
+++ b/repondeur/tests/test_lectures_add.py
@@ -23,7 +23,7 @@ def test_lecture_link_not_in_navbar_if_no_lecture(app):
     assert 'title="Aller à la liste des lectures">Lectures</a></li>' not in resp.text
 
 
-def test_get_form(app):
+def test_get_form(app, dossiers):
     resp = app.get("/lectures/add", user="user@example.com")
 
     assert resp.status_code == 200
@@ -55,11 +55,11 @@ def test_get_form(app):
 
 
 @responses.activate
-def test_post_form(app):
+def test_post_form(app, texte_an, dossiers):
     from zam_repondeur.models import Lecture
 
     assert not Lecture.exists(
-        chambre="an", session="15", num_texte=269, partie=None, organe="PO717460"
+        chambre="an", session="15", texte=texte_an, partie=None, organe="PO717460"
     )
 
     responses.add(
@@ -130,11 +130,11 @@ def test_post_form(app):
     assert "Lecture créée avec succès," in resp.text
 
     lecture = Lecture.get(
-        chambre="an", session="15", num_texte=269, partie=None, organe="PO717460"
+        chambre="an", session="15", texte=texte_an, partie=None, organe="PO717460"
     )
     assert lecture.chambre == "an"
     assert lecture.titre == "Première lecture – Titre lecture"
-    assert lecture.dossier_legislatif == "Sécurité sociale : loi de financement 2018"
+    assert lecture.dossier.titre == "Sécurité sociale : loi de financement 2018"
     result = (
         "Assemblée nationale, 15e législature, Séance publique, Première lecture, "
         "texte nº\u00a0269"
@@ -156,13 +156,13 @@ def test_post_form(app):
 
 
 @responses.activate
-def test_post_form_senat_2019(app):
+def test_post_form_senat_2019(app, texte_senat):
     from zam_repondeur.models import Lecture
 
     assert not Lecture.exists(
         chambre="senat",
         session="2018-2019",
-        num_texte=106,
+        texte=texte_senat,
         partie=None,
         organe="PO78718",
     )
@@ -229,13 +229,13 @@ def test_post_form_senat_2019(app):
     lecture = Lecture.get(
         chambre="senat",
         session="2018-2019",
-        num_texte=106,
+        texte=texte_senat,
         partie=None,
         organe="PO78718",
     )
     assert lecture.chambre == "senat"
     assert lecture.titre == "Première lecture – Titre lecture"
-    assert lecture.dossier_legislatif == "Sécurité sociale : loi de financement 2019"
+    assert lecture.dossier.titre == "Sécurité sociale : loi de financement 2019"
     result = "Sénat, session 2018-2019, Séance publique, Première lecture, texte nº 106"
     assert str(lecture) == result
 
@@ -244,7 +244,11 @@ def test_post_form_already_exists(app, lecture_an):
     from zam_repondeur.models import Lecture
 
     assert Lecture.exists(
-        chambre="an", session="15", num_texte=269, partie=None, organe="PO717460"
+        chambre="an",
+        session="15",
+        texte=lecture_an.texte,
+        partie=None,
+        organe="PO717460",
     )
 
     # We cannot use form.submit() given the form is dynamic and does not

--- a/repondeur/tests/test_lectures_list.py
+++ b/repondeur/tests/test_lectures_list.py
@@ -16,17 +16,17 @@ def test_get_list_empty(app):
 
 
 @pytest.fixture
-def lecture_commission(db):
+def lecture_commission(db, texte_an, dossier_an):
     from zam_repondeur.models import Lecture
 
     with transaction.manager:
         lecture = Lecture.create(
             chambre="an",
             session="15",
-            num_texte=269,
+            texte=texte_an,
             titre="Numéro lecture – Titre lecture",
             organe="PO420120",
-            dossier_legislatif="Titre dossier legislatif",
+            dossier=dossier_an,
         )
 
     return lecture
@@ -50,10 +50,10 @@ def test_get_list_reverse_datetime_order(app, lecture_an):
         lecture2 = Lecture.create(
             chambre=lecture_an.chambre,
             session=lecture_an.session,
-            num_texte=lecture_an.num_texte + 1,
+            texte=lecture_an.texte,
             titre="Numéro lecture – Titre lecture 2",
             organe=lecture_an.organe,
-            dossier_legislatif=lecture_an.dossier_legislatif,
+            dossier=lecture_an.dossier,
         )
         title2 = str(lecture2)
         DBSession.add(lecture2)

--- a/repondeur/tests/test_manual_refresh.py
+++ b/repondeur/tests/test_manual_refresh.py
@@ -78,7 +78,7 @@ def test_post_form(app, lecture_an, article1_an):
     lecture_an = Lecture.get(
         chambre=lecture_an.chambre,
         session=lecture_an.session,
-        num_texte=lecture_an.num_texte,
+        texte=lecture_an.texte,
         partie=None,
         organe=lecture_an.organe,
     )
@@ -95,7 +95,7 @@ def test_post_form(app, lecture_an, article1_an):
         lecture = Lecture.get(
             chambre=lecture_an.chambre,
             session=lecture_an.session,
-            num_texte=lecture_an.num_texte,
+            texte=lecture_an.texte,
             partie=None,
             organe=lecture_an.organe,
         )

--- a/repondeur/tests/test_upload_csv.py
+++ b/repondeur/tests/test_upload_csv.py
@@ -132,7 +132,7 @@ class TestPostForm:
         lecture = Lecture.get(
             chambre=lecture_an.chambre,
             session=lecture_an.session,
-            num_texte=lecture_an.num_texte,
+            texte=lecture_an.texte,
             partie=None,
             organe=lecture_an.organe,
         )

--- a/repondeur/tests/test_upload_liasse_xml.py
+++ b/repondeur/tests/test_upload_liasse_xml.py
@@ -45,7 +45,7 @@ def test_upload_liasse_success(app, lecture_essoc):
     lecture = Lecture.get(
         chambre=lecture_essoc.chambre,
         session=lecture_essoc.session,
-        num_texte=lecture_essoc.num_texte,
+        texte=lecture_essoc.texte,
         partie=None,
         organe=lecture_essoc.organe,
     )
@@ -76,7 +76,7 @@ def test_upload_liasse_with_table(app, lecture_essoc):
     lecture = Lecture.get(
         chambre=lecture_essoc.chambre,
         session=lecture_essoc.session,
-        num_texte=lecture_essoc.num_texte,
+        texte=lecture_essoc.texte,
         partie=None,
         organe=lecture_essoc.organe,
     )
@@ -121,7 +121,7 @@ def test_upload_liasse_missing_file(app, lecture_essoc):
     lecture = Lecture.get(
         chambre=lecture_essoc.chambre,
         session=lecture_essoc.session,
-        num_texte=lecture_essoc.num_texte,
+        texte=lecture_essoc.texte,
         partie=None,
         organe=lecture_essoc.organe,
     )

--- a/repondeur/zam_repondeur/data.py
+++ b/repondeur/zam_repondeur/data.py
@@ -5,9 +5,6 @@ from pyramid.config import Configurator
 from redis import Redis
 from redis_lock import Lock
 
-from zam_repondeur.fetch.an.dossiers.dossiers_legislatifs import (
-    get_dossiers_legislatifs
-)
 from zam_repondeur.fetch.an.organes_acteurs import get_organes_acteurs
 
 from .initialize import needs_init
@@ -46,10 +43,8 @@ class DataRepository:
 
     @needs_init
     def load_data(self) -> None:
-        dossiers = get_dossiers_legislatifs(*self.legislatures)
         organes, acteurs = get_organes_acteurs()
         with Lock(self.connection, "data"):
-            self.connection.set("dossiers", pickle.dumps(dossiers))
             self.connection.set("organes", pickle.dumps(organes))
             self.connection.set("acteurs", pickle.dumps(acteurs))
 

--- a/repondeur/zam_repondeur/fetch/an/amendements.py
+++ b/repondeur/zam_repondeur/fetch/an/amendements.py
@@ -362,7 +362,7 @@ def _get_parent(
 def build_url(lecture: Lecture, numero_prefixe: str = "") -> str:
 
     legislature = int(lecture.session)
-    texte = f"{lecture.num_texte:04}"
+    texte = f"{lecture.texte.numero:04}"
 
     # The 1st "lecture" of the "projet de loi de finances" (PLF) has two parts
     if lecture.partie == 1:

--- a/repondeur/zam_repondeur/fetch/an/dossiers/models.py
+++ b/repondeur/zam_repondeur/fetch/an/dossiers/models.py
@@ -1,7 +1,4 @@
-from dataclasses import dataclass
-from datetime import date
 from enum import Enum
-from typing import List, Optional
 
 
 class Chambre(Enum):
@@ -34,56 +31,3 @@ class TypeTexte(Enum):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}.{self.name}"
-
-
-@dataclass
-class Texte:
-    uid: str
-    type_: TypeTexte
-    numero: int
-    titre_long: str
-    titre_court: str
-    date_depot: Optional[date]
-
-
-@dataclass
-class Lecture:
-    chambre: Chambre
-    titre: str
-    texte: Texte
-    organe: str
-    partie: Optional[int] = None
-
-    @property
-    def key(self) -> str:
-        return f"{self.texte.uid}-{self.organe}-{self.partie or ''}"
-
-    @property
-    def label(self) -> str:
-        if self.partie == 1:
-            partie = " (première partie)"
-        elif self.partie == 2:
-            partie = " (seconde partie)"
-        else:
-            partie = ""
-        return f"{self.chambre} – {self.titre} – Texte Nº {self.texte.numero}{partie}"
-
-    def get_session(self) -> str:
-        if self.chambre == Chambre.AN:
-            return "15"  # FIXME
-        else:
-            if not self.texte.date_depot:
-                return "2017-2018"  # FIXME: sane default?
-            # The session changes the first working day of October.
-            if self.texte.date_depot.month >= 10:
-                year = self.texte.date_depot.year
-            else:
-                year = self.texte.date_depot.year - 1
-            return f"{year}-{year + 1}"
-
-
-@dataclass
-class Dossier:
-    uid: str
-    titre: str
-    lectures: List[Lecture]

--- a/repondeur/zam_repondeur/fetch/articles.py
+++ b/repondeur/zam_repondeur/fetch/articles.py
@@ -34,12 +34,14 @@ SENAT_URL = "https://www.senat.fr/"
 def get_possible_texte_urls(lecture: Lecture) -> List[str]:
     if lecture.chambre == "an":
         return [
-            f"{AN_URL}{lecture.session}/projets/pl{lecture.num_texte:04}.asp",
-            f"{AN_URL}{lecture.session}/propositions/pion{lecture.num_texte:04}.asp",
-            f"{AN_URL}{lecture.session}/ta-commission/r{lecture.num_texte:04}-a0.asp",
+            f"{AN_URL}{lecture.session}/projets/pl{lecture.texte.numero:04}.asp",
+            f"{AN_URL}{lecture.session}/propositions/pion{lecture.texte.numero:04}.asp",
+            f"{AN_URL}{lecture.session}/ta-commission/r{lecture.texte.numero:04}-a0.asp",  # noqa
         ]
     else:
-        return [f"{SENAT_URL}leg/pjl{lecture.session[2:4]}-{lecture.num_texte:03}.html"]
+        return [
+            f"{SENAT_URL}leg/pjl{lecture.session[2:4]}-{lecture.texte.numero:03}.html"
+        ]
 
 
 def parse_first_working_url(urls: List[str]) -> List[dict]:

--- a/repondeur/zam_repondeur/fetch/senat/amendements.py
+++ b/repondeur/zam_repondeur/fetch/senat/amendements.py
@@ -182,8 +182,8 @@ def _fetch_all(lecture: Lecture) -> List[OrderedDict]:
     """
     # Fallback to commissions.
     urls = [
-        f"{BASE_URL}/amendements/{lecture.session}/{lecture.num_texte}/jeu_complet_{lecture.session}_{lecture.num_texte}.csv",  # noqa
-        f"{BASE_URL}/amendements/commissions/{lecture.session}/{lecture.num_texte}/jeu_complet_commission_{lecture.session}_{lecture.num_texte}.csv",  # noqa
+        f"{BASE_URL}/amendements/{lecture.session}/{lecture.texte.numero}/jeu_complet_{lecture.session}_{lecture.texte.numero}.csv",  # noqa
+        f"{BASE_URL}/amendements/commissions/{lecture.session}/{lecture.texte.numero}/jeu_complet_commission_{lecture.session}_{lecture.texte.numero}.csv",  # noqa
     ]
 
     for url in urls:

--- a/repondeur/zam_repondeur/fetch/senat/derouleur.py
+++ b/repondeur/zam_repondeur/fetch/senat/derouleur.py
@@ -127,17 +127,19 @@ IDTXTS = {
 
 def derouleur_urls(lecture: Lecture, phase: str) -> Iterator[str]:
     idtxts = (
-        IDTXTS.get(lecture.session, {}).get(lecture.num_texte, {}).get(lecture.partie)
+        IDTXTS.get(lecture.session, {})
+        .get(lecture.texte.numero, {})
+        .get(lecture.partie)
     )
     if idtxts is not None:
         for idtxt in idtxts:
             yield (
-                f"{BASE_URL}/en{phase}/{lecture.session}/{lecture.num_texte}"
+                f"{BASE_URL}/en{phase}/{lecture.session}/{lecture.texte.numero}"
                 f"/liste_discussion_{idtxt}.json"
             )
     else:
         yield (
-            f"{BASE_URL}/en{phase}/{lecture.session}/{lecture.num_texte}"
+            f"{BASE_URL}/en{phase}/{lecture.session}/{lecture.texte.numero}"
             f"/liste_discussion.json"
         )
 

--- a/repondeur/zam_repondeur/models/__init__.py
+++ b/repondeur/zam_repondeur/models/__init__.py
@@ -7,9 +7,11 @@ from .base import Base, DBSession, log_query_with_origin  # noqa
 
 from .amendement import Amendement, AVIS  # noqa
 from .article import Article, ArticleUserContent  # noqa
+from .dossier import Dossier  # noqa
 from .lecture import Lecture, CHAMBRES, SESSIONS  # noqa
 from .users import Team, User  # noqa
 from .table import UserTable  # noqa
+from .texte import Texte  # noqa
 
 from .events.base import Event  # noqa
 from .events.amendement import *  # noqa

--- a/repondeur/zam_repondeur/models/amendement.py
+++ b/repondeur/zam_repondeur/models/amendement.py
@@ -456,7 +456,7 @@ class Amendement(Base):
             "comments": self.user_content.comments or "",
             "parent": self.parent and self.parent.num_disp or "",
             "chambre": self.lecture.chambre,
-            "num_texte": self.lecture.num_texte,
+            "num_texte": self.lecture.texte.numero,
             "organe": self.lecture.organe,
             "session": self.lecture.session,
             "article": self.article.format(),

--- a/repondeur/zam_repondeur/models/dossier.py
+++ b/repondeur/zam_repondeur/models/dossier.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Column, DateTime, Integer, Text
+from sqlalchemy.orm import relationship
+
+from .base import Base, DBSession
+
+
+class Dossier(Base):
+    __tablename__ = "dossiers"
+
+    pk = Column(Integer, primary_key=True)
+
+    uid = Column(Text)
+    titre = Column(Text)
+
+    lectures = relationship("Lecture", back_populates="dossier")
+
+    created_at = Column(DateTime)
+    modified_at = Column(DateTime)
+
+    __repr_keys__ = ("pk", "uid", "titre")
+
+    @classmethod
+    def get(cls, uid: str) -> Optional["Dossier"]:
+        res: Optional["Dossier"] = DBSession.query(cls).filter(cls.uid == uid).first()
+        return res
+
+    @classmethod
+    def exists(cls, uid: str) -> bool:
+        res: bool = DBSession.query(
+            DBSession.query(cls).filter(cls.uid == uid).exists()
+        ).scalar()
+        return res
+
+    @classmethod
+    def create(cls, uid: str, titre: str) -> "Dossier":
+        now = datetime.utcnow()
+        dossier = cls(uid=uid, titre=titre, created_at=now, modified_at=now)
+        DBSession.add(dossier)
+        return dossier

--- a/repondeur/zam_repondeur/models/lecture.py
+++ b/repondeur/zam_repondeur/models/lecture.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, TYPE_CHECKING
 
 from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, Text, desc
 from sqlalchemy.orm import joinedload, relationship
@@ -9,6 +9,11 @@ from .article import Article
 from .base import Base, DBSession
 from .division import SubDiv
 from .users import Team
+
+# Make these types available to mypy, but avoid circular imports
+if TYPE_CHECKING:
+    from .dossier import Dossier  # noqa
+    from .texte import Texte  # noqa
 
 
 CHAMBRES = {"an": "Assemblée nationale", "senat": "Sénat"}
@@ -23,10 +28,9 @@ class Lecture(Base):
     __tablename__ = "lectures"
     __table_args__ = (
         Index(
-            "ix_lectures__chambre__session__num_texte__partie__organe",
+            "ix_lectures__chambre__session__partie__organe",
             "chambre",
             "session",
-            "num_texte",
             "partie",
             "organe",
             unique=True,
@@ -36,11 +40,9 @@ class Lecture(Base):
     pk = Column(Integer, primary_key=True)
     chambre = Column(Text)
     session = Column(Text)
-    num_texte = Column(Integer)
     partie = Column(Integer, nullable=True)  # only for PLF
     organe = Column(Text)
     titre = Column(Text)
-    dossier_legislatif = Column(Text)
     created_at = Column(DateTime)
     modified_at = Column(DateTime)
     amendements = relationship(
@@ -52,19 +54,15 @@ class Lecture(Base):
     articles = relationship(
         Article, back_populates="lecture", cascade="all, delete-orphan"
     )
+    dossier_pk: int = Column(Integer, ForeignKey("dossiers.pk"))
+    dossier: "Dossier" = relationship("Dossier", back_populates="lectures")
+    texte_pk: int = Column(Integer, ForeignKey("textes.pk"))
+    texte: "Texte" = relationship("Texte", back_populates="lectures")
 
     owned_by_team_pk = Column(Integer, ForeignKey("teams.pk"), nullable=True)
     owned_by_team = relationship("Team", backref="lectures")
 
-    __repr_keys__ = (
-        "pk",
-        "chambre",
-        "session",
-        "organe",
-        "num_texte",
-        "partie",
-        "owned_by_team",
-    )
+    __repr_keys__ = ("pk", "chambre", "session", "organe", "partie", "owned_by_team")
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Lecture):
@@ -72,7 +70,7 @@ class Lecture(Base):
         return bool(
             self.chambre == other.chambre
             and self.session == other.session
-            and self.num_texte == other.num_texte
+            and self.texte.numero == other.texte.numero
             and self.partie == other.partie
             and self.organe == other.organe
         )
@@ -125,15 +123,15 @@ class Lecture(Base):
             partie = " (2nde partie)"
         else:
             partie = ""
-        return f"texte nº\u00a0{self.num_texte}{partie}"
+        return f"texte nº\u00a0{self.texte.numero}{partie}"
 
     def __lt__(self, other: Any) -> bool:
         if type(self) != type(other):
             return NotImplemented
-        return (self.chambre, self.session, self.num_texte, self.organe) < (
+        return (self.chambre, self.session, self.texte.numero, self.organe) < (
             other.chambre,
             other.session,
-            other.num_texte,
+            other.texte.numero,
             other.organe,
         )
 
@@ -179,7 +177,7 @@ class Lecture(Base):
         cls,
         chambre: str,
         session: str,
-        num_texte: int,
+        texte: "Texte",
         partie: Optional[int],
         organe: str,
         *options: Any,
@@ -189,7 +187,7 @@ class Lecture(Base):
             .filter(
                 cls.chambre == chambre,
                 cls.session == session,
-                cls.num_texte == num_texte,
+                cls.texte == texte,
                 cls.partie == partie,
                 cls.organe == organe,
             )
@@ -203,7 +201,7 @@ class Lecture(Base):
         cls,
         chambre: str,
         session: str,
-        num_texte: int,
+        texte: "Texte",
         partie: Optional[int],
         organe: str,
     ) -> bool:
@@ -212,7 +210,7 @@ class Lecture(Base):
             .filter(
                 cls.chambre == chambre,
                 cls.session == session,
-                cls.num_texte == num_texte,
+                cls.texte == texte,
                 cls.partie == partie,
                 cls.organe == organe,
             )
@@ -225,10 +223,10 @@ class Lecture(Base):
         cls,
         chambre: str,
         session: str,
-        num_texte: int,
+        texte: "Texte",
         titre: str,
         organe: str,
-        dossier_legislatif: str,
+        dossier: "Dossier",
         partie: Optional[int] = None,
         owned_by_team: Optional[Team] = None,
     ) -> "Lecture":
@@ -236,10 +234,10 @@ class Lecture(Base):
         lecture = cls(
             chambre=chambre,
             session=session,
-            num_texte=num_texte,
+            texte=texte,
             titre=titre,
             organe=organe,
-            dossier_legislatif=dossier_legislatif,
+            dossier=dossier,
             partie=partie,
             owned_by_team=owned_by_team,
             created_at=now,
@@ -254,7 +252,9 @@ class Lecture(Base):
             partie = f"-{self.partie}"
         else:
             partie = ""
-        return f"{self.chambre}.{self.session}.{self.num_texte}{partie}.{self.organe}"
+        return (
+            f"{self.chambre}.{self.session}.{self.texte.numero}{partie}.{self.organe}"
+        )
 
     def find_article(self, subdiv: SubDiv) -> Optional[Article]:
         article: Article

--- a/repondeur/zam_repondeur/models/texte.py
+++ b/repondeur/zam_repondeur/models/texte.py
@@ -1,0 +1,80 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Column, DateTime, Integer, Text
+from sqlalchemy.orm import relationship
+
+from .base import Base, DBSession
+
+
+class Texte(Base):
+    __tablename__ = "textes"
+
+    pk = Column(Integer, primary_key=True)
+
+    uid = Column(Text)
+    type_ = Column(Text)
+    numero = Column(Integer)
+    titre_long = Column(Text)
+    titre_court = Column(Text)
+    date_depot = Column(DateTime)
+
+    lectures = relationship("Lecture", back_populates="texte")
+
+    created_at = Column(DateTime)
+    modified_at = Column(DateTime)
+
+    __repr_keys__ = (
+        "pk",
+        "uid",
+        "type_",
+        "numero",
+        "titre_long",
+        "titre_court",
+        "date_depot",
+    )
+
+    @classmethod
+    def get(cls, uid: str) -> Optional["Texte"]:
+        res: Optional["Texte"] = DBSession.query(cls).filter(cls.uid == uid).first()
+        return res
+
+    @classmethod
+    def get_by_numero(cls, numero: int) -> Optional["Texte"]:
+        res: Optional["Texte"] = DBSession.query(cls).filter(
+            cls.numero == numero
+        ).first()
+        return res
+
+    @classmethod
+    def exists(cls, uid: str) -> bool:
+        res: bool = DBSession.query(
+            DBSession.query(cls).filter(cls.uid == uid).exists()
+        ).scalar()
+        return res
+
+    @classmethod
+    def create(
+        cls,
+        uid: str,
+        type_: str,
+        numero: int,
+        titre_long: str,
+        titre_court: str,
+        date_depot: datetime,
+        lectures: list,
+    ) -> "Texte":
+        now = datetime.utcnow()
+        texte = cls(
+            uid=uid,
+            type_=type_,
+            numero=numero,
+            titre_long=titre_long,
+            titre_court=titre_court,
+            date_depot=date_depot,
+            lectures=lectures,
+            created_at=now,
+            modified_at=now,
+        )
+        DBSession.add(texte)
+        return texte

--- a/repondeur/zam_repondeur/resources.py
+++ b/repondeur/zam_repondeur/resources.py
@@ -12,6 +12,7 @@ from zam_repondeur.models import (
     Article,
     DBSession,
     Lecture,
+    Texte,
     User,
     UserTable,
 )
@@ -129,13 +130,11 @@ class LectureResource(Resource):
         return self.model()
 
     def model(self, *options: Any) -> Lecture:
+        texte = Texte.get_by_numero(self.num_texte)
+        if texte is None:
+            raise ResourceNotFound(self)
         lecture = Lecture.get(
-            self.chambre,
-            self.session,
-            self.num_texte,
-            self.partie,
-            self.organe,
-            *options,
+            self.chambre, self.session, texte, self.partie, self.organe, *options
         )
         if lecture is None:
             raise ResourceNotFound(self)

--- a/repondeur/zam_repondeur/templates/_base_visionneuse.html
+++ b/repondeur/zam_repondeur/templates/_base_visionneuse.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset=utf-8>
 <meta name=viewport content="width=device-width,minimum-scale=1,initial-scale=1,shrink-to-fit=no">
-<title>{{ lecture.dossier_legislatif }} — {{ lecture }}</title>
+<title>{{ lecture.dossier.titre }} — {{ lecture }}</title>
 <link rel=icon href="data:;base64,iVBORw0KGgo=">
 <link rel="stylesheet" type="text/css" href="{{ request.static_url('zam_repondeur:static/css/fonts.css') }}">
 <link rel="stylesheet" type="text/css" href="{{ request.static_url('zam_repondeur:static/css/visionneuse.css') }}">

--- a/repondeur/zam_repondeur/templates/amendements.html
+++ b/repondeur/zam_repondeur/templates/amendements.html
@@ -15,7 +15,7 @@
 </svg>
 
 <h1>Index des amendements</h1>
-<h2 class="subtitle">{{ lecture.dossier_legislatif }}</h2>
+<h2 class="subtitle">{{ lecture.dossier.titre }}</h2>
 <h3 class="subtitle">{{ lecture }}</h3>
 {{ macros.update_informations(lecture, request.resource_url(context.parent, 'journal')) }}
 {% set count = amendements| length %}

--- a/repondeur/zam_repondeur/templates/articles_list.html
+++ b/repondeur/zam_repondeur/templates/articles_list.html
@@ -54,7 +54,7 @@
 {% endblock %}
 
 {% block title %}
-  <h1>{{ lecture.dossier_legislatif }}</h1>
+  <h1>{{ lecture.dossier.titre }}</h1>
 {% endblock %}
 
 {% block main %}

--- a/repondeur/zam_repondeur/templates/lectures_list.html
+++ b/repondeur/zam_repondeur/templates/lectures_list.html
@@ -69,7 +69,7 @@
     {% for lecture in lectures %}
         <div class="lecture box">
             <div>
-                <h3>{{ lecture.dossier_legislatif }}</h3>
+                <h3>{{ lecture.dossier.titre }}</h3>
                 <div class="details">{{ lecture }}</div>
                 {% if lecture.amendements %}
                     <em>{{ lecture.amendements|length }} amendements</em>

--- a/repondeur/zam_repondeur/templates/print.html
+++ b/repondeur/zam_repondeur/templates/print.html
@@ -6,7 +6,7 @@
 </head>
 <body>
   <div class="first-page page">
-    <h1>{{ lecture.dossier_legislatif }}</h1>
+    <h1>{{ lecture.dossier.titre }}</h1>
     <h2>{{ lecture }}</h2>
   </div>
   <main>

--- a/repondeur/zam_repondeur/views/download.py
+++ b/repondeur/zam_repondeur/views/download.py
@@ -48,7 +48,7 @@ def download_amendements(context: LectureResource, request: Request) -> Response
 
         response = FileResponse(tmp_file_path)
         attach_name = (
-            f"lecture-{lecture.chambre}-{lecture.session}-{lecture.num_texte}-"
+            f"lecture-{lecture.chambre}-{lecture.session}-{lecture.texte.numero}-"
             f"{lecture.organe}.{fmt}"
         )
         response.content_type = content_type
@@ -89,7 +89,7 @@ def export_pdf(context: LectureResource, request: Request) -> Response:
         attach_name = (
             f"amendement{'s' if len(nums) > 1 else ''}-"
             f"{','.join(str(num) for num in nums)}-"
-            f"{lecture.chambre}-{lecture.session}-{lecture.num_texte}-"
+            f"{lecture.chambre}-{lecture.session}-{lecture.texte.numero}-"
             f"{lecture.organe}.pdf"
         )
         response.content_type = "application/pdf"


### PR DESCRIPTION
Currently missing:

* [ ] migrations
* [ ] decision to create all lecture then activate(== make visible) on user creation (might initiate that status thing with archived lectures)
* [ ] clean up the mess with Chambres and TypeTextes, turn these into models too?
* [ ] better use of new models (we used to iterate on all values)
* [ ] find a way to speed up tests with scoped fixtures

There are TODO to help, `pytest --stepwise` is your friend 😅 