### PR TITLE
Fix email field width in identification form

### DIFF
--- a/repondeur/zam_repondeur/static/css/zam.css
+++ b/repondeur/zam_repondeur/static/css/zam.css
@@ -469,6 +469,7 @@ label[for="emptytable"] abbr {
             font-weight: 600;
         }
         .intro fieldset input {
+            width: 100%;
             font-size: 1.2rem;
         }
     .intro .controls {


### PR DESCRIPTION
It looked OK in Firefox but not in Webkit :(