### PR TITLE
Use database delete cascades (aka "passive deletes") to speed up dossier deactivation

### DIFF
--- a/repondeur/db_migrations/versions/aa4e290e0df2_add_delete_cascades.py
+++ b/repondeur/db_migrations/versions/aa4e290e0df2_add_delete_cascades.py
@@ -1,0 +1,189 @@
+"""Add delete cascades
+
+Revision ID: aa4e290e0df2
+Revises: d535af9f8a61
+Create Date: 2019-08-28 15:37:37.101589
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "aa4e290e0df2"
+down_revision = "d535af9f8a61"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint(
+        "amendement_user_contents_amendement_pk_fkey",
+        "amendement_user_contents",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        op.f("amendement_user_contents_amendement_pk_fkey"),
+        "amendement_user_contents",
+        "amendements",
+        ["amendement_pk"],
+        ["pk"],
+        ondelete="cascade",
+    )
+
+    op.drop_constraint("amendements_lecture_pk_fkey", "amendements", type_="foreignkey")
+    op.create_foreign_key(
+        op.f("amendements_lecture_pk_fkey"),
+        "amendements",
+        "lectures",
+        ["lecture_pk"],
+        ["pk"],
+        ondelete="cascade",
+    )
+
+    op.drop_constraint(
+        "article_user_contents_article_pk_fkey",
+        "article_user_contents",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        op.f("article_user_contents_article_pk_fkey"),
+        "article_user_contents",
+        "articles",
+        ["article_pk"],
+        ["pk"],
+        ondelete="cascade",
+    )
+
+    op.drop_constraint("articles_lecture_pk_fkey", "articles", type_="foreignkey")
+    op.create_foreign_key(
+        op.f("articles_lecture_pk_fkey"),
+        "articles",
+        "lectures",
+        ["lecture_pk"],
+        ["pk"],
+        ondelete="cascade",
+    )
+
+    op.drop_constraint("events_amendement_pk_fkey", "events", type_="foreignkey")
+    op.create_foreign_key(
+        op.f("events_amendement_pk_fkey"),
+        "events",
+        "amendements",
+        ["amendement_pk"],
+        ["pk"],
+        ondelete="cascade",
+    )
+
+    op.drop_constraint("events_article_pk_fkey", "events", type_="foreignkey")
+    op.create_foreign_key(
+        op.f("events_article_pk_fkey"),
+        "events",
+        "articles",
+        ["article_pk"],
+        ["pk"],
+        ondelete="cascade",
+    )
+
+    op.drop_constraint("events_lecture_pk_fkey", "events", type_="foreignkey")
+    op.create_foreign_key(
+        op.f("events_lecture_pk_fkey"),
+        "events",
+        "lectures",
+        ["lecture_pk"],
+        ["pk"],
+        ondelete="cascade",
+    )
+
+    op.drop_constraint(
+        "shared_tables_lecture_pk_fkey", "shared_tables", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        op.f("shared_tables_lecture_pk_fkey"),
+        "shared_tables",
+        "lectures",
+        ["lecture_pk"],
+        ["pk"],
+        ondelete="cascade",
+    )
+
+    op.drop_constraint("user_tables_lecture_pk_fkey", "user_tables", type_="foreignkey")
+    op.create_foreign_key(
+        op.f("user_tables_lecture_pk_fkey"),
+        "user_tables",
+        "lectures",
+        ["lecture_pk"],
+        ["pk"],
+        ondelete="cascade",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("user_tables_lecture_pk_fkey"), "user_tables", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "user_tables_lecture_pk_fkey", "user_tables", "lectures", ["lecture_pk"], ["pk"]
+    )
+
+    op.drop_constraint(
+        op.f("shared_tables_lecture_pk_fkey"), "shared_tables", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "shared_tables_lecture_pk_fkey",
+        "shared_tables",
+        "lectures",
+        ["lecture_pk"],
+        ["pk"],
+    )
+
+    op.drop_constraint(op.f("events_lecture_pk_fkey"), "events", type_="foreignkey")
+    op.create_foreign_key(
+        "events_lecture_pk_fkey", "events", "lectures", ["lecture_pk"], ["pk"]
+    )
+
+    op.drop_constraint(op.f("events_article_pk_fkey"), "events", type_="foreignkey")
+    op.create_foreign_key(
+        "events_article_pk_fkey", "events", "articles", ["article_pk"], ["pk"]
+    )
+
+    op.drop_constraint(op.f("events_amendement_pk_fkey"), "events", type_="foreignkey")
+    op.create_foreign_key(
+        "events_amendement_pk_fkey", "events", "amendements", ["amendement_pk"], ["pk"]
+    )
+
+    op.drop_constraint(op.f("articles_lecture_pk_fkey"), "articles", type_="foreignkey")
+    op.create_foreign_key(
+        "articles_lecture_pk_fkey", "articles", "lectures", ["lecture_pk"], ["pk"]
+    )
+
+    op.drop_constraint(
+        op.f("article_user_contents_article_pk_fkey"),
+        "article_user_contents",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "article_user_contents_article_pk_fkey",
+        "article_user_contents",
+        "articles",
+        ["article_pk"],
+        ["pk"],
+    )
+
+    op.drop_constraint(
+        op.f("amendements_lecture_pk_fkey"), "amendements", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "amendements_lecture_pk_fkey", "amendements", "lectures", ["lecture_pk"], ["pk"]
+    )
+
+    op.drop_constraint(
+        op.f("amendement_user_contents_amendement_pk_fkey"),
+        "amendement_user_contents",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "amendement_user_contents_amendement_pk_fkey",
+        "amendement_user_contents",
+        "amendements",
+        ["amendement_pk"],
+        ["pk"],
+    )

--- a/repondeur/zam_repondeur/models/amendement.py
+++ b/repondeur/zam_repondeur/models/amendement.py
@@ -186,7 +186,9 @@ class AmendementUserContent(Base):
     reponse: Optional[str] = Column(Text, nullable=True)
     comments: Optional[str] = Column(Text, nullable=True)
 
-    amendement_pk: int = Column(Integer, ForeignKey("amendements.pk"), nullable=False)
+    amendement_pk: int = Column(
+        Integer, ForeignKey("amendements.pk", ondelete="cascade"), nullable=False
+    )
     amendement: "Amendement" = relationship("Amendement", back_populates="user_content")
 
     __repr_keys__ = ("pk", "amendement_pk", "avis")
@@ -285,7 +287,7 @@ class Amendement(Base):
         post_update=True,
     )
 
-    lecture_pk: int = Column(Integer, ForeignKey("lectures.pk"))
+    lecture_pk: int = Column(Integer, ForeignKey("lectures.pk", ondelete="cascade"))
     lecture: "Lecture" = relationship("Lecture", back_populates="amendements")
 
     article_pk: int = Column(Integer, ForeignKey("articles.pk"))
@@ -315,12 +317,14 @@ class Amendement(Base):
         uselist=False,
         lazy="joined",
         cascade="all, delete-orphan",
+        passive_deletes=True,
     )
 
     events = relationship(
         "Event",
         order_by="Event.created_at.desc()",
         cascade="all, delete-orphan",
+        passive_deletes=True,
         backref="amendement",
     )
 

--- a/repondeur/zam_repondeur/models/article.py
+++ b/repondeur/zam_repondeur/models/article.py
@@ -64,7 +64,9 @@ class ArticleUserContent(Base):
     title: Optional[str] = Column(Text, nullable=True)
     presentation: Optional[str] = Column(Text, nullable=True)
 
-    article_pk: int = Column(Integer, ForeignKey("articles.pk"), nullable=False)
+    article_pk: int = Column(
+        Integer, ForeignKey("articles.pk", ondelete="cascade"), nullable=False
+    )
     article: "Article" = relationship("Article", back_populates="user_content")
 
 
@@ -78,7 +80,9 @@ class Article(Base):
     pk: int = Column(Integer, primary_key=True)
     created_at: datetime = Column(DateTime, nullable=False)
 
-    lecture_pk: int = Column(Integer, ForeignKey("lectures.pk"), nullable=False)
+    lecture_pk: int = Column(
+        Integer, ForeignKey("lectures.pk", ondelete="cascade"), nullable=False
+    )
     lecture: "Lecture" = relationship("Lecture", back_populates="articles")
     type: str = Column(Text, nullable=False, default="")
     num: str = Column(Text, nullable=False, default="")
@@ -98,12 +102,14 @@ class Article(Base):
         uselist=False,
         lazy="joined",
         cascade="all, delete-orphan",
+        passive_deletes=True,
     )
 
     events = relationship(
         "Event",
         order_by="Event.created_at.desc()",
         cascade="all, delete-orphan",
+        passive_deletes=True,
         backref="article",
     )
 

--- a/repondeur/zam_repondeur/models/events/base.py
+++ b/repondeur/zam_repondeur/models/events/base.py
@@ -25,9 +25,13 @@ class Event(Base):
     user_pk = Column(Integer, ForeignKey("users.pk"), nullable=True)
     user = relationship(User)
 
-    amendement_pk = Column(Integer, ForeignKey("amendements.pk"), nullable=True)
+    amendement_pk = Column(
+        Integer, ForeignKey("amendements.pk", ondelete="cascade"), nullable=True
+    )
     dossier_pk = Column(Integer, ForeignKey("dossiers.pk"), nullable=True)
-    article_pk = Column(Integer, ForeignKey("articles.pk"), nullable=True)
+    article_pk = Column(
+        Integer, ForeignKey("articles.pk", ondelete="cascade"), nullable=True
+    )
 
     data = Column(JSONType, nullable=True)
     meta = Column(JSONType, nullable=True)

--- a/repondeur/zam_repondeur/models/events/lecture.py
+++ b/repondeur/zam_repondeur/models/events/lecture.py
@@ -12,9 +12,15 @@ from .base import Event
 
 
 class LectureEvent(Event):
-    lecture_pk = Column(Integer, ForeignKey("lectures.pk"))
+    lecture_pk = Column(Integer, ForeignKey("lectures.pk", ondelete="cascade"))
     lecture = relationship(
-        Lecture, backref=backref("events", order_by="Event.created_at.desc()")
+        Lecture,
+        backref=backref(
+            "events",
+            order_by="Event.created_at.desc()",
+            cascade="all, delete-orphan",
+            passive_deletes=True,
+        ),
     )
 
     details_template = Template("")

--- a/repondeur/zam_repondeur/models/lecture.py
+++ b/repondeur/zam_repondeur/models/lecture.py
@@ -41,9 +41,13 @@ class Lecture(Base, LastEventMixin):
         order_by=(Amendement.position, Amendement.num),
         back_populates="lecture",
         cascade="all, delete-orphan",
+        passive_deletes=True,
     )
     articles = relationship(
-        Article, back_populates="lecture", cascade="all, delete-orphan"
+        Article,
+        back_populates="lecture",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
     )
 
     dossier_pk = Column(Integer, ForeignKey("dossiers.pk"))

--- a/repondeur/zam_repondeur/models/table.py
+++ b/repondeur/zam_repondeur/models/table.py
@@ -23,9 +23,14 @@ class UserTable(Base):
     user_pk: int = Column(Integer, ForeignKey("users.pk"), nullable=False)
     user: User = relationship(User, back_populates="tables")
 
-    lecture_pk: int = Column(Integer, ForeignKey("lectures.pk"), nullable=False)
+    lecture_pk: int = Column(
+        Integer, ForeignKey("lectures.pk", ondelete="cascade"), nullable=False
+    )
     lecture: Lecture = relationship(
-        Lecture, backref=backref("user_tables", cascade="all, delete-orphan")
+        Lecture,
+        backref=backref(
+            "user_tables", cascade="all, delete-orphan", passive_deletes=True
+        ),
     )
 
     amendements = relationship(
@@ -62,9 +67,14 @@ class SharedTable(Base):
     titre: str = Column(Text, nullable=False)
     slug: str = Column(Text, nullable=False)
 
-    lecture_pk: int = Column(Integer, ForeignKey("lectures.pk"), nullable=False)
+    lecture_pk: int = Column(
+        Integer, ForeignKey("lectures.pk", ondelete="cascade"), nullable=False
+    )
     lecture: Lecture = relationship(
-        Lecture, backref=backref("shared_tables", cascade="all, delete-orphan")
+        Lecture,
+        backref=backref(
+            "shared_tables", cascade="all, delete-orphan", passive_deletes=True
+        ),
     )
 
     amendements = relationship(


### PR DESCRIPTION

See:
- https://docs.sqlalchemy.org/en/13/orm/collections.html#using-passive-deletes
- https://docs.sqlalchemy.org/en/13/orm/cascades.html#delete