### PR TITLE
Use Rollup to generate a manifest file for Pyramid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,7 @@ ENV/
 
 # redis
 *.rdb
+
+# static assets
+repondeur/zam_repondeur/static/node_modules/*
+repondeur/zam_repondeur/static/manifest.json

--- a/repondeur/zam_repondeur/assets.py
+++ b/repondeur/zam_repondeur/assets.py
@@ -1,41 +1,10 @@
-from hashlib import sha256
-from typing import BinaryIO, Dict, cast
-
 from pyramid.config import Configurator
-from pyramid.path import AssetResolver
-from pyramid.path import PkgResourcesAssetDescriptor as AssetDescriptor
-from pyramid.request import Request
-from pyramid.static import QueryStringCacheBuster
+from pyramid.static import ManifestCacheBuster
 
 
 def includeme(config: Configurator) -> None:
     config.add_static_view("static", "static", cache_max_age=3600)
     config.add_cache_buster(
         "zam_repondeur:static/",
-        ContentHashCacheBuster(package="zam_repondeur", base_path="static/"),
+        ManifestCacheBuster("zam_repondeur:static/manifest.json"),
     )
-
-
-class ContentHashCacheBuster(QueryStringCacheBuster):
-    def __init__(self, package: str, base_path: str, param: str = "x") -> None:
-        super().__init__(param=param)
-        self.asset_resolver = AssetResolver(package)
-        self.base_path = base_path
-        self.token_cache: Dict[str, str] = {}
-
-    def tokenize(self, request: Request, subpath: str, kw: Dict[str, str]) -> str:
-        token = self.token_cache.get(subpath)
-        if token is None:
-            asset = self._resolve_asset(subpath)
-            self.token_cache[subpath] = token = self._hash_asset(asset)
-        return token
-
-    def _resolve_asset(self, subpath: str) -> AssetDescriptor:
-        return self.asset_resolver.resolve(self.base_path + subpath)
-
-    def _hash_asset(self, asset: AssetDescriptor) -> str:
-        hash_ = sha256()
-        with cast(BinaryIO, asset.stream()) as stream:
-            for block in iter(lambda: stream.read(4096), b""):
-                hash_.update(block)
-        return hash_.hexdigest()

--- a/repondeur/zam_repondeur/static/README.md
+++ b/repondeur/zam_repondeur/static/README.md
@@ -1,0 +1,9 @@
+# Building assets
+
+1. Install npm
+2. Go to repondeur/zam_repondeur/static/
+3. `npm install`
+4. `npm run-script build`
+
+At that point, a `manifest.json` should be generated,
+ready to be consumed by the `ManifestCacheBuster` from Pyramid.

--- a/repondeur/zam_repondeur/static/package-lock.json
+++ b/repondeur/zam_repondeur/static/package-lock.json
@@ -1,0 +1,75 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@types/estree": {
+      "version": "0.0.40",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.40.tgz",
+      "integrity": "sha1-Dmy5ubvQmAMfoZ5LToExvHDl3hM=",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "12.12.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
+      "integrity": "sha1-HB1uPHXbpGbgMmlI1W6L1yoZA9I=",
+      "dev": true
+    },
+    "acorn": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha1-lJ028sKSU12mAig1hsJHfFfrLWw=",
+      "dev": true
+    },
+    "hasha": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+      "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
+      "dev": true,
+      "requires": {
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "rollup": {
+      "version": "1.27.8",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.27.8.tgz",
+      "integrity": "sha512-EVoEV5rAWl+5clnGznt1KY8PeVkzVQh/R0d2s3gHEkN7gfoyC4JmvIVuCtPbYE8NM5Ep/g+nAmvKXBjzaqTsHA==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
+      }
+    },
+    "rollup-plugin-hash": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-hash/-/rollup-plugin-hash-1.3.0.tgz",
+      "integrity": "sha512-a/DUrOlXOqCpwCF+dPXEPDlqbOMkfXDWEWOeVU2bhrW18Dbh0nu2JLLrS3FIiasVrDZhoxhwhSkV/dg15gwPyw==",
+      "dev": true,
+      "requires": {
+        "hasha": "^2.2.0"
+      }
+    }
+  }
+}

--- a/repondeur/zam_repondeur/static/package.json
+++ b/repondeur/zam_repondeur/static/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "build": "rollup --config"
+  },
+  "devDependencies": {
+    "rollup": "^1.27.8",
+    "rollup-plugin-hash": "^1.3.0"
+  },
+  "dependencies": {}
+}

--- a/repondeur/zam_repondeur/static/rollup.config.js
+++ b/repondeur/zam_repondeur/static/rollup.config.js
@@ -1,0 +1,16 @@
+import hash from 'rollup-plugin-hash'
+
+export default {
+  input: 'js/zam.js',
+  plugins: [
+    hash({
+      dest: 'js/build/zam.[hash].js',
+      manifest: 'manifest.json',
+      manifestKey: 'js/zam.js',
+    })
+  ],
+  output: {
+    file: 'js/build/zam.js',
+    format: 'iife'
+  }
+}


### PR DESCRIPTION
Cache busting by query parameters being not always considered as relevant by proxies, we use Rollup to generate a manifest file which can be consumed by Pyramid’s ManifestCacheBuster class.

At the moment, this is only a POC that converts the `zam.js` file.